### PR TITLE
Add HomeCoin stable adaptor

### DIFF
--- a/src/adapters/peggedAssets/bacon-protocol-home/index.ts
+++ b/src/adapters/peggedAssets/bacon-protocol-home/index.ts
@@ -1,0 +1,38 @@
+const sdk = require("@defillama/sdk");
+import {
+  ChainBlocks,
+  PeggedIssuanceAdapter,
+} from "../peggedAsset.type";
+
+const chainContracts = {
+    ethereum: {
+        issued: "0xb8919522331C59f5C16bDfAA6A121a6E03A91F62",
+    },
+};
+
+async function ethereumMinted() {
+return async function (
+    _timestamp: number,
+    _ethBlock: number,
+    _chainBlocks: ChainBlocks
+) {
+    const totalSupply = (
+      await sdk.api.abi.call({
+        abi: "erc20:totalSupply",
+        target: chainContracts.ethereum.issued,
+        block: _ethBlock,
+        chain: "ethereum",
+      })
+    ).output;
+    return { peggedUSD: totalSupply / 10 ** 6 };
+  };
+}
+
+const adapter: PeggedIssuanceAdapter = {
+  ethereum: {
+    minted: ethereumMinted(),
+    unreleased: async () => ({}),
+  },
+};
+
+export default adapter;

--- a/src/adapters/peggedAssets/index.ts
+++ b/src/adapters/peggedAssets/index.ts
@@ -57,6 +57,7 @@ import par from "./par-stablecoin";
 import ush from "./hedge-usd";
 import threeusd from "./three-usd";
 import sigmausd from "./sigmausd";
+import home from "./bacon-protocol-home";
 
 export default {
   tether,
@@ -118,4 +119,5 @@ export default {
   "hedge-usd": ush,
   "three-usd": threeusd,
   sigmausd,
+  home,
 };


### PR DESCRIPTION
Adding HomeCoin (HOME) to the stablecoin list.

See https://github.com/DefiLlama/DefiLlama-Adapters/pull/3366 for TVL adaptor.

Some basic info:

Twitter Link:
https://twitter.com/homecoinfinance

List of audit links if any:
https://files.homecoin.finance/bacon-protocol-full-audit.pdf

Website Link:
https://www.homecoin.finance/

Logo 
https://files.homecoin.finance/homecoin-icon-500.png

Current TVL:
6,747,567

Chain:
Ethereum

Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
bacon-protocol-home

Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
20520

Short Description (to be shown on DefiLlama):
A StableCoin backed by U.S. Homes

Token address and ticker if any:
HOME
0xb8919522331C59f5C16bDfAA6A121a6E03A91F62