### PR TITLE
Rename Elrond to MultiversX and add USDT & BUSD

### DIFF
--- a/src/adapters/peggedAssets/binance-usd/index.ts
+++ b/src/adapters/peggedAssets/binance-usd/index.ts
@@ -530,7 +530,7 @@ const adapter: PeggedIssuanceAdapter = {
     unreleased: async () => ({}),
     bsc: bridgedSupply("klaytn", 18, chainContracts.klaytn.bridgedFromBSC),
   },
-  multiversx: {
+  elrond: {
     minted: async () => ({}),
     unreleased: async () => ({}),
     ethereum: multiversxBridged("BUSD-40b57e", 6),

--- a/src/adapters/peggedAssets/binance-usd/index.ts
+++ b/src/adapters/peggedAssets/binance-usd/index.ts
@@ -302,6 +302,33 @@ async function chainUnreleased(chain: string, decimals: number) {
   };
 }
 
+async function multiversxBridged(tokenID: string, decimals: number) {
+  return async function (
+    _timestamp: number,
+    _ethBlock: number,
+    _chainBlocks: ChainBlocks
+  ) {
+    let balances = {} as Balances;
+    const res = await retry(
+      async (_bail: any) =>
+        await axios.get(
+          `https://api.multiversx.com/tokens/${tokenID}/supply`
+        )
+    );
+    console.info("MultiversX success BUSD");
+    const supply = res?.data?.data?.supply / 10 ** decimals;
+    sumSingleBalance(
+      balances,
+      "peggedUSD",
+      supply,
+      "adastra",
+      false,
+      "Ethereum"
+    );
+    return balances;
+  };
+}
+
 const adapter: PeggedIssuanceAdapter = {
   ethereum: {
     minted: chainMinted("ethereum", 18),
@@ -502,6 +529,11 @@ const adapter: PeggedIssuanceAdapter = {
     minted: async () => ({}),
     unreleased: async () => ({}),
     bsc: bridgedSupply("klaytn", 18, chainContracts.klaytn.bridgedFromBSC),
+  },
+  multiversx: {
+    minted: async () => ({}),
+    unreleased: async () => ({}),
+    ethereum: multiversxBridged("BUSD-40b57e", 6),
   },
   dogechain: {
     minted: async () => ({}),

--- a/src/adapters/peggedAssets/helper/chains.json
+++ b/src/adapters/peggedAssets/helper/chains.json
@@ -67,7 +67,7 @@
   "kava",
   "ronin",
   "liquidchain",
-  "elrond",
+  "multiversx",
   "neo",
   "nahmii",
   "ultra",

--- a/src/adapters/peggedAssets/helper/chains.json
+++ b/src/adapters/peggedAssets/helper/chains.json
@@ -67,7 +67,7 @@
   "kava",
   "ronin",
   "liquidchain",
-  "multiversx",
+  "elrond",
   "neo",
   "nahmii",
   "ultra",

--- a/src/adapters/peggedAssets/tether/index.ts
+++ b/src/adapters/peggedAssets/tether/index.ts
@@ -736,6 +736,33 @@ async function polyNetworkBridged(
   };
 }
 
+async function multiversxBridged(tokenID: string, decimals: number) {
+  return async function (
+    _timestamp: number,
+    _ethBlock: number,
+    _chainBlocks: ChainBlocks
+  ) {
+    let balances = {} as Balances;
+    const res = await retry(
+      async (_bail: any) =>
+        await axios.get(
+          `https://api.multiversx.com/tokens/${tokenID}/supply`
+        )
+    );
+    console.info("MultiversX success USDT");
+    const supply = res?.data?.data?.supply / 10 ** decimals;
+    sumSingleBalance(
+      balances,
+      "peggedUSD",
+      supply,
+      "adastra",
+      false,
+      "Ethereum"
+    );
+    return balances;
+  };
+}
+
 async function kavaBridged() {
   return async function (
     _timestamp: number,
@@ -1202,6 +1229,11 @@ const adapter: PeggedIssuanceAdapter = {
     minted: async () => ({}),
     unreleased: async () => ({}),
     ethereum: bridgedSupply("klaytn", 6, chainContracts.klaytn.bridgedFromETH),
+  },
+  multiversx: {
+    minted: async () => ({}),
+    unreleased: async () => ({}),
+    ethereum: multiversxBridged("USDT-f8c08c", 6),
   },
   canto: {
     minted: async () => ({}),

--- a/src/adapters/peggedAssets/tether/index.ts
+++ b/src/adapters/peggedAssets/tether/index.ts
@@ -1230,7 +1230,7 @@ const adapter: PeggedIssuanceAdapter = {
     unreleased: async () => ({}),
     ethereum: bridgedSupply("klaytn", 6, chainContracts.klaytn.bridgedFromETH),
   },
-  multiversx: {
+  elrond: {
     minted: async () => ({}),
     unreleased: async () => ({}),
     ethereum: multiversxBridged("USDT-f8c08c", 6),

--- a/src/adapters/peggedAssets/usd-coin/index.ts
+++ b/src/adapters/peggedAssets/usd-coin/index.ts
@@ -619,7 +619,7 @@ async function multiversxBridged(tokenID: string, decimals: number) {
           `https://api.multiversx.com/tokens/${tokenID}/supply`
         )
     );
-    console.info("multiversx success USDC");
+    console.info("MultiversX success USDC");
     const supply = res?.data?.data?.supply / 10 ** decimals;
     sumSingleBalance(
       balances,

--- a/src/adapters/peggedAssets/usd-coin/index.ts
+++ b/src/adapters/peggedAssets/usd-coin/index.ts
@@ -1040,7 +1040,7 @@ const adapter: PeggedIssuanceAdapter = {
     unreleased: async () => ({}),
     ethereum: bridgedSupply("klaytn", 6, chainContracts.klaytn.bridgedFromETH),
   },
-  multiversx: {
+  elrond: {
     minted: async () => ({}),
     unreleased: async () => ({}),
     ethereum: multiversxBridged("USDC-c76f1f", 6),

--- a/src/adapters/peggedAssets/usd-coin/index.ts
+++ b/src/adapters/peggedAssets/usd-coin/index.ts
@@ -606,7 +606,7 @@ async function nearBridged(address: string, decimals: number) {
   };
 }
 
-async function elrondBridged(tokenID: string, decimals: number) {
+async function multiversxBridged(tokenID: string, decimals: number) {
   return async function (
     _timestamp: number,
     _ethBlock: number,
@@ -616,10 +616,10 @@ async function elrondBridged(tokenID: string, decimals: number) {
     const res = await retry(
       async (_bail: any) =>
         await axios.get(
-          `https://gateway.elrond.com/network/esdt/supply/${tokenID}`
+          `https://api.multiversx.com/tokens/${tokenID}/supply`
         )
     );
-    console.info("elrond success USDC");
+    console.info("multiversx success USDC");
     const supply = res?.data?.data?.supply / 10 ** decimals;
     sumSingleBalance(
       balances,
@@ -1040,10 +1040,10 @@ const adapter: PeggedIssuanceAdapter = {
     unreleased: async () => ({}),
     ethereum: bridgedSupply("klaytn", 6, chainContracts.klaytn.bridgedFromETH),
   },
-  elrond: {
+  multiversx: {
     minted: async () => ({}),
     unreleased: async () => ({}),
-    ethereum: elrondBridged("USDC-c76f1f", 6),
+    ethereum: multiversxBridged("USDC-c76f1f", 6),
   },
   canto: {
     minted: async () => ({}),

--- a/src/utils/normalizeChain.ts
+++ b/src/utils/normalizeChain.ts
@@ -463,8 +463,8 @@ export const chainCoingeckoIds = {
     categories: ["EVM"],
     chainId: 55,
   },
-  Elrond: {
-    geckoId: "elrond-erd-2",
+  MultiversX: {
+    geckoId: "multiversx",
     symbol: "EGLD",
     cmcId: "6892",
   },
@@ -991,8 +991,8 @@ export function getChainDisplayName(
       return "Polis";
     case "zyx":
       return "ZYX";
-    case "elrond":
-      return "Elrond";
+    case "multiversx":
+      return "MultiversX";
     case "stellar":
       return "Stellar";
     case "shiden":

--- a/src/utils/normalizeChain.ts
+++ b/src/utils/normalizeChain.ts
@@ -463,7 +463,7 @@ export const chainCoingeckoIds = {
     categories: ["EVM"],
     chainId: 55,
   },
-  MultiversX: {
+  Elrond: {
     geckoId: "multiversx",
     symbol: "EGLD",
     cmcId: "6892",
@@ -991,7 +991,7 @@ export function getChainDisplayName(
       return "Polis";
     case "zyx":
       return "ZYX";
-    case "multiversx":
+    case "elrond":
       return "MultiversX";
     case "stellar":
       return "Stellar";


### PR DESCRIPTION
- Renamed Elrond to MultiversX
- Fixed API call from https://gateway.elrond.com/network/esdt/supply/[TOKEN_ID] to https://api.multiversx.com/tokens/[TOKEN_ID]/supply
- Added USDT and BUSD