### PR TITLE
Add clevUSD

### DIFF
--- a/src/adapters/peggedAssets/clever-usd/index.ts
+++ b/src/adapters/peggedAssets/clever-usd/index.ts
@@ -1,0 +1,50 @@
+const sdk = require("@defillama/sdk");
+import { sumSingleBalance } from "../helper/generalUtil";
+import {
+  ChainBlocks,
+  PeggedIssuanceAdapter,
+  Balances,
+} from "../peggedAsset.type";
+
+type ChainContracts = {
+  [chain: string]: {
+    [contract: string]: string[];
+  };
+};
+
+const chainContracts: ChainContracts = {
+  ethereum: {
+    issued: ["0x3c20ac688410be8f391be1fb00afc5c212972f86"],
+  },
+};
+
+async function chainMinted(chain: string) {
+  return async function (
+    _timestamp: number,
+    _ethBlock: number,
+    _chainBlocks: ChainBlocks
+  ) {
+    let balances = {} as Balances;
+    for (let issued of chainContracts[chain].issued) {
+      const totalSupply = (
+        await sdk.api.abi.call({
+          abi: "erc20:totalSupply",
+          target: issued,
+          block: _chainBlocks?.[chain],
+          chain: chain,
+        })
+      ).output;
+      sumSingleBalance(balances, "peggedUSD", totalSupply / 10 ** 18, "issued", false);
+    }
+    return balances;
+  };
+}
+
+const adapter: PeggedIssuanceAdapter = {
+  ethereum: {
+    minted: chainMinted("ethereum"),
+    unreleased: async () => ({}),
+  },
+};
+
+export default adapter;

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -2254,4 +2254,24 @@ export default [
   twitter: "https://twitter.com/overnight_fi",
   wiki: null,
 },
+{
+  id: "113",
+  name: "CLever USD",
+  address: "bsc:0xE68b79e51bf826534Ff37AA9CeE71a3842ee9c70",
+  symbol: "clevUSD",
+  url: "https://clever.aladdin.club/",
+  description:
+    "ClevUSD are synthetic versions of their associated real token, representing the future yield of CLever strategies. Each clevToken is backed by one or more equivalent real Tokens in the system.",
+  mintRedeemDescription:
+    "ClevUSD can be farmed in CLever liquidity pools or swapped for more of the original token.",
+  onCoinGecko: "true",
+  gecko_id: "clever-usd",
+  cmcId: null,
+  pegType: "peggedUSD",
+  pegMechanism: "crypto-backed",
+  priceSource: "defillama",
+  auditLinks: null,
+  twitter: "https://twitter.com/0xc_lever",
+  wiki: null,
+},
 ] as PeggedAsset[];

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -2257,7 +2257,7 @@ export default [
 {
   id: "113",
   name: "CLever USD",
-  address: "bsc:0xE68b79e51bf826534Ff37AA9CeE71a3842ee9c70",
+  address: "0x3C20Ac688410bE8F391bE1fb00AFc5C212972F86",
   symbol: "clevUSD",
   url: "https://clever.aladdin.club/",
   description:


### PR DESCRIPTION
Add the ClevUSD Stable coin to Defillama.

Website: https://clever.aladdin.club/
Price Tickers:
https://www.coingecko.com/en/coins/clever-usd