### PR TITLE
recover the data of Pando USD

### DIFF
--- a/src/adapters/peggedAssets/pando-usd/index.ts
+++ b/src/adapters/peggedAssets/pando-usd/index.ts
@@ -34,7 +34,7 @@ async function pusdMinted() {
 
 const adapter: PeggedIssuanceAdapter = {
   mixin: {
-    minted: async () => ({}), // pusdMinted(), Pando was hacked, de-listing until API works/reserves verified
+    minted: pusdMinted(),
     unreleased: async () => ({}),
   },
 };


### PR DESCRIPTION
According to the official post, only the Rings protocol was affected. Attackers didn't mint Pando USD.

https://pando.im/news/2022/2022-11-06-alert-to-pando-community-hack-of-pando-rings/