### PR TITLE
Add EUROe on Solana

### DIFF
--- a/src/adapters/peggedAssets/euroe-stablecoin/index.ts
+++ b/src/adapters/peggedAssets/euroe-stablecoin/index.ts
@@ -1,5 +1,6 @@
 const sdk = require("@defillama/sdk");
 import { sumSingleBalance } from "../helper/generalUtil";
+import { solanaMintedOrBridged } from "../helper/getSupply";
 import {
   ChainBlocks,
   PeggedIssuanceAdapter,
@@ -71,8 +72,11 @@ const adapter: PeggedIssuanceAdapter = {
   avalanche: {
     minted: chainMinted("avalanche", 6),
     unreleased: async () => ({}),
+  },
+  solana: {
+    minted: solanaMintedOrBridged(["2VhjJ9WxaGC3EZFwJG9BDUs9KxKCAjQY4vgd1qxgYWVg"]),
+    unreleased: async () => ({}),
   }
-  
 };
 
 export default adapter;


### PR DESCRIPTION
You can cross-reference the address in the official documentation [here](https://dev.euroe.com/docs/Stablecoin/contract-addresses#solana) on Wednesday, 23 Aug 2023.