### PR TITLE
Rootstock rebranding (ex RSK)

### DIFF
--- a/src/utils/normalizeChain.ts
+++ b/src/utils/normalizeChain.ts
@@ -1021,7 +1021,7 @@ export function getChainDisplayName(
     case "neo":
       return "NEO";
     case "rsk":
-      return "RSK";
+      return "Rootstock";
     case "osmosis":
       return "Osmosis";
     case "iotex":


### PR DESCRIPTION
What I'm trying to fix is this issue: stablecoins on Rootstock are not being considered in the chain TVL because they are shown as `RSK` instead of `Rootstock`. 
Note: this change is necessary but I don't know if it is enough, please let me know if more changes are required to fix this.

Rootstock main dashboard, with empty value for `Stables`:

<img width="977" alt="Screenshot 2023-12-22 at 12 32 11" src="https://github.com/DefiLlama/peggedassets-server/assets/3451282/b7e59596-d573-4654-a5ab-a8c57a86d3c8">

RSK stables/pegged-assets (instead of associated to Rootstock):

<img width="1158" alt="Screenshot 2023-12-22 at 12 32 42" src="https://github.com/DefiLlama/peggedassets-server/assets/3451282/a4b454a6-6625-483c-8f8f-a55da39e6db7">
