### PR TITLE
add LUSD for zkSync Era and Polygon zkEVM

### DIFF
--- a/src/adapters/peggedAssets/liquity-usd/index.ts
+++ b/src/adapters/peggedAssets/liquity-usd/index.ts
@@ -119,7 +119,6 @@ const adapter: PeggedIssuanceAdapter = {
       chainContracts.arbitrum.bridgedFromETH
     ),
   },
-  /*
   polygon_zkevm: {
     minted: async () => ({}),
     unreleased: async () => ({}),
@@ -130,7 +129,6 @@ const adapter: PeggedIssuanceAdapter = {
     unreleased: async () => ({}),
     ethereum: bridgedSupply("era", 18, chainContracts.era.bridgedFromETH),
   }
-  */
 };
 
 export default adapter;


### PR DESCRIPTION
These were previously commented out. LUSD has low supply on each chain, but it should still be tracked imo.