### PR TITLE
fix near stablecoin balances

### DIFF
--- a/src/adapters/peggedAssets/llama-helper/near.js
+++ b/src/adapters/peggedAssets/llama-helper/near.js
@@ -46,6 +46,14 @@ const tokenMapping = {
   "token.burrow.near": { name: "burrow", decimals: 18 },
   "token.paras.near": { name: "paras", decimals: 18 },
   "token.pembrock.near": { name: "pembrock", decimals: 18 },
+  "17208628f84f5d6ad33f0da3bbbeb27ffcb398eac501a31bd6ad2011e36133a1": {
+    name: "usd-coin",
+    decimals: 6,
+  },
+  "usdt.tether-token.near": {
+    name: "tether",
+    decimals: 6,
+  },
 };
 
 async function view_account(account_id) {

--- a/src/adapters/peggedAssets/tether/index.ts
+++ b/src/adapters/peggedAssets/tether/index.ts
@@ -293,6 +293,7 @@ const chainContracts: ChainContracts = {
     bridgedFromETH: ["0xc9BAA8cfdDe8E328787E29b4B078abf2DaDc2055"], // multichain
   },
   near: {
+    issued: ["usdt.tether-token.near"],
     bridgedFromETH: [
       "dac17f958d2ee523a2206206994597c13d831ec7.factory.bridge.near",
     ], // rainbow bridge
@@ -739,6 +740,25 @@ async function nearBridged(address: string, decimals: number) {
       supply / 10 ** decimals,
       address,
       true
+    );
+    return balances;
+  };
+}
+
+async function nearMint(address: string, decimals: number) {
+  return async function (
+    _timestamp: number,
+    _ethBlock: number,
+    _chainBlocks: ChainBlocks
+  ) {
+    let balances = {} as Balances;
+    const mintedAmount = await nearCall(address, "ft_total_supply");
+    sumSingleBalance(
+      balances,
+      "peggedUSD",
+      mintedAmount / 10 ** decimals,
+      address,
+      false
     );
     return balances;
   };
@@ -1239,7 +1259,7 @@ const adapter: PeggedIssuanceAdapter = {
     unreleased: usdtApiUnreleased("reserve_balance_tezos"),
   },
   near: {
-    minted: async () => ({}),
+    minted: nearMint(chainContracts.near.issued[0], 6),
     unreleased: async () => ({}),
     ethereum: nearBridged(chainContracts.near.bridgedFromETH[0], 6),
   },


### PR DESCRIPTION
This PR has two parts:

1. Added native USDC and USDT contract addresses to the token mapping in the near.js helper file 
2. Added a function to calculate native USDT supply on NEAR to the tether index.ts file