### PR TITLE
update GYEN and ZUSD

### DIFF
--- a/src/adapters/peggedAssets/gyen/index.ts
+++ b/src/adapters/peggedAssets/gyen/index.ts
@@ -115,6 +115,10 @@ const adapter: PeggedIssuanceAdapter = {
     minted: gmoAPIChainMinted("XLM"),
     unreleased: async () => ({}),
   },
+  solana: {
+    minted: gmoAPIChainMinted("SOLANA"),
+    unreleased: async () => ({}),
+  },
 };
 
 export default adapter;

--- a/src/adapters/peggedAssets/zusd/index.ts
+++ b/src/adapters/peggedAssets/zusd/index.ts
@@ -115,6 +115,10 @@ const adapter: PeggedIssuanceAdapter = {
     minted: gmoAPIChainMinted("XLM"),
     unreleased: async () => ({}),
   },
+  solana: {
+    minted: gmoAPIChainMinted("SOLANA"),
+    unreleased: async () => ({}),
+  },
 };
 
 export default adapter;


### PR DESCRIPTION
Hi Team, We added GYEN/ZUSD on Solana Network.

GYEN: Crn4x1Y2HUKko7ox2EZMT6N2t2ZyH7eKtwkBGVnhEq1g
ZUSD: FrBfWJ4qE5sCzKm3k3JaAtqZcXUh4LvJygDeketsrsH4

Tests are passed. Thank you!

```
% npm run-script test zusd peggedUSD

> defillama-server@1.0.0 pretest
> npm run prebuild


> defillama-server@1.0.0 prebuild
> npx ts-node src/cli/buildRequires.ts


> defillama-server@1.0.0 test
> cd src/adapters/peggedAssets && npx ts-node test "zusd" "peggedUSD"

(node:82076) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
GMO API success
GMO API success
--- ethereum ---
minted                    18.75 M
circulating               18.75 M
unreleased                0
--- optimism ---
minted                    0
unreleased                0
ethereum                  0
circulating               0
--- arbitrum ---
minted                    0
unreleased                0
ethereum                  0
circulating               0
--- stellar ---
minted                    264.00 k
circulating               264.00 k
unreleased                0
--- solana ---
unreleased                0
minted                    0
circulating               0
------ Total Circulating ------
Total circulating         19.01 M
Total unreleased          0
```



```
% npm run-script test gyen peggedJPY

> defillama-server@1.0.0 pretest
> npm run prebuild


> defillama-server@1.0.0 prebuild
> npx ts-node src/cli/buildRequires.ts


> defillama-server@1.0.0 test
> cd src/adapters/peggedAssets && npx ts-node test "gyen" "peggedJPY"

(node:44731) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
GMO API success
GMO API success
--- ethereum ---
minted                    2.05 B
circulating               2.03 B
unreleased                0
--- optimism ---
ethereum                  100
circulating               100
minted                    0
unreleased                0
--- arbitrum ---
ethereum                  24.00 M
circulating               24.00 M
minted                    0
unreleased                0
--- stellar ---
minted                    19.99 M
circulating               19.99 M
unreleased                0
--- solana ---
unreleased                0
minted                    0
circulating               0
------ Total Circulating ------
Total circulating         2.07 B
Total unreleased          0
```