### PR TITLE
add gai-stablecoin(pegged with USD）

### DIFF
--- a/src/adapters/peggedAssets/gai-stablecoin/index.ts
+++ b/src/adapters/peggedAssets/gai-stablecoin/index.ts
@@ -1,0 +1,51 @@
+const sdk = require("@defillama/sdk");
+import { sumSingleBalance } from "../helper/generalUtil";
+
+import {
+  ChainBlocks,
+  PeggedIssuanceAdapter,
+  Balances,
+} from "../peggedAsset.type";
+
+type ChainContracts = {
+  [chain: string]: {
+    [contract: string]: string[];
+  };
+};
+
+const chainContracts: ChainContracts = {
+  manta: {
+    issued: ["0xcd91716ef98798A85E79048B78287B13ae6b99b2"],
+  },
+};
+
+async function chainMinted(chain: string, decimals: number) {
+  return async function (
+    _timestamp: number,
+    _ethBlock: number,
+    _chainBlocks: ChainBlocks
+  ) {
+    let balances = {} as Balances;
+    for (let issued of chainContracts[chain].issued) {
+      const totalSupply = (
+        await sdk.api.abi.call({
+          abi: "erc20:totalSupply",
+          target: issued,
+          block: _chainBlocks?.[chain],
+          chain: chain,
+        })
+      ).output;
+      sumSingleBalance(balances, "peggedUSD", totalSupply / 10 ** decimals);
+    }
+    return balances;
+  };
+}
+
+const adapter: PeggedIssuanceAdapter = {
+  manta: {
+    minted: chainMinted("manta", 18),
+    unreleased: async () => ({}),
+  },
+};
+
+export default adapter;

--- a/src/adapters/peggedAssets/helper/chains.json
+++ b/src/adapters/peggedAssets/helper/chains.json
@@ -140,5 +140,6 @@
   "concordium",
   "pulse",
   "sui",
-  "q"
+  "q",
+  "manta"
 ]

--- a/src/adapters/peggedAssets/index.ts
+++ b/src/adapters/peggedAssets/index.ts
@@ -48,6 +48,7 @@ import usd from "./usd";
 import dei from "./dei-token";
 import usn from "./usn";
 import bai from "./bai-stablecoin";
+import gai from "./gai-stablecoin";
 import eurt from "./tether-eurt";
 import eurc from "./euro-coin";
 import stasis from "./stasis-eurs";
@@ -217,6 +218,7 @@ export default {
   usd,
   "dei-token": dei,
   "bai-stablecoin": bai,
+  "gai-stablecoin": gai,
   usn,
   "tether-eurt": eurt,
   "euro-coin": eurc,

--- a/src/adapters/peggedAssets/llama-helper/portedTokens.js
+++ b/src/adapters/peggedAssets/llama-helper/portedTokens.js
@@ -770,6 +770,14 @@ function fixAstarBalances(balances) {
   return fixBalances(balances, mapping)
 }
 
+function fixMantaBalances(balances) {
+  const mapping = {
+    '0xcd91716ef98798A85E79048B78287B13ae6b99b2': { coingeckoId: 'goku-money-gai', decimals: 18, },
+  }
+
+  return fixBalances(balances, mapping)
+}
+
 function fixHPBBalances(balances) {
   const mapping = {
     '0xBE05Ac1FB417c9EA435b37a9Cecd39Bc70359d31': { coingeckoId: 'high-performance-blockchain', decimals: 18, },
@@ -1012,6 +1020,7 @@ const fixBalancesMapping = {
   avax: fixAvaxBalances,
   evmos: b => fixBalances(b, evmosFixMapping, { removeUnmapped: false }),
   astar: fixAstarBalances,
+  manta: fixMantaBalances,
   shiden: fixShidenBalances,
   cronos: b => fixBalances(b, cronosFixMapping, { removeUnmapped: false }),
   tezos: fixTezosBalances,

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -3381,4 +3381,24 @@ export default [
     twitter: "https://twitter.com/protocol_fx",
     wiki: null,
   },
+  {
+    id: "169",
+    name: "GAI Stablecoin",
+    address: "manta:0xcd91716ef98798A85E79048B78287B13ae6b99b2",
+    symbol: "GAI",
+    url: "https://www.goku.money/",
+    description:
+      "Goku Money is a decentralized borrowing protocol on Manta that allows you to draw interest-free loans against multiple collateral assets (e.g. MANTA, TIA, USDT, and etc.). Loans are paid out in GAI (a USD pegged stablecoin).",
+    mintRedeemDescription:
+      "Using the Goku Money app, users mint GAI by depositing an accepted collateral asset into a vault. When the loan is repaid to retrieve the collateral, the paid back GAI is burned.",
+    onCoinGecko: "true",
+    gecko_id: "goku-money-gai",
+    cmcId: null,
+    pegType: "peggedUSD",
+    pegMechanism: "crypto-backed",
+    priceSource: "coingecko",
+    auditLinks: null,
+    twitter: "https://twitter.com/goku_stable",
+    wiki: null,
+  },
 ] as PeggedAsset[];


### PR DESCRIPTION
Add Gai Stablecoin to DefiLlama

Our website is `https://goku.money/`

GAI `https://www.coingecko.com/en/coins/goku-money-gai`

And here is the test logs.


`npx ts-node test gai-stablecoin/index.ts peggedUSD`

```
------ ERROR ------
      Bridge data not found on chain manta. Use sumSingleBalance from helper/generalUtil to add bridge data.
--- manta ---
minted                    69.50 k
circulating               69.50 k
unreleased                0
------ Total Circulating ------
Total circulating         69.50 k
Total unreleased          0
```