### PR TITLE
fix: update URL to get IST supply

### DIFF
--- a/src/adapters/peggedAssets/inter-stable-token/index.ts
+++ b/src/adapters/peggedAssets/inter-stable-token/index.ts
@@ -32,7 +32,7 @@ async function agoricMinted(decimals: number) {
     const res = await retry(
       async (_bail: any) =>
         await axios.get(
-          "https://rest.cosmos.directory/agoric/cosmos/bank/v1beta1/supply/uist"
+          "https://rest.cosmos.directory/agoric/cosmos/bank/v1beta1/supply/by_denom?denom=uist"
         )
     );
     const istInfo = res?.data?.amount;


### PR DESCRIPTION
Hey DefiLlama team, we recently performed a chain upgrade that upgraded cosmos-sdk from 0.45 to 0.46 and as a result, the URL scheme for getting supply for a certain denom needs to be updated.

```
curl https://rest.cosmos.directory/agoric/cosmos/bank/v1beta1/supply/by_denom?denom=uist
{
  "amount": {
    "denom": "uist",
    "amount": "1384674829604"
  }
}                                                                                                                                                                                                                                                                                                                        
```

vs

```
curl https://rest.cosmos.directory/agoric/cosmos/bank/v1beta1/supply/uist
{
  "code": 12,
  "message": "Not Implemented",
  "details": [
  ]
}%                                                                                                                                                                                                                                                                                                                        
```