### PR TITLE
Bean

### DIFF
--- a/src/adapters/peggedAssets/bean/index.ts
+++ b/src/adapters/peggedAssets/bean/index.ts
@@ -1,0 +1,45 @@
+const sdk = require("@defillama/sdk");;
+import { sumSingleBalance } from "../helper/generalUtil";
+import { ChainBlocks, PeggedIssuanceAdapter } from "../peggedAsset.type";
+
+const BEAN_ERC20_V1 = "0xdc59ac4fefa32293a95889dc396682858d52e5db";
+const BEAN_ERC20_V2 = "0xbea0000029ad1c77d3d5d23ba2d8893db9d1efab";
+
+// After the flashloan governance exploit,
+// Beanstalk was offline for 3.5 months before launching with a new token.
+const START_BLOCK = 12974077;
+const EXPLOIT_BLOCK = 14602790;
+const REPLANT_BLOCK = 15278082;
+
+async function ethereumMinted(_timestamp: number, ethBlock: number, _chainBlocks: ChainBlocks) {
+
+  const balances = {};
+
+  if (ethBlock < START_BLOCK || (ethBlock > EXPLOIT_BLOCK && ethBlock < REPLANT_BLOCK)) {
+    // There was no canonical bean token during this period
+    sumSingleBalance(balances, "peggedUSD", 0, 'issued', false);
+  } else {
+
+    const beanToken = ethBlock <= EXPLOIT_BLOCK ? BEAN_ERC20_V1 : BEAN_ERC20_V2;
+    const totalSupply = (
+      await sdk.api.abi.call({
+        abi: "erc20:totalSupply",
+        target: beanToken,
+        block: ethBlock,
+        chain: "ethereum",
+      })
+    ).output;
+
+    sumSingleBalance(balances, "peggedUSD", totalSupply / 10 ** 6, 'issued', false);
+  }
+  return balances;
+};
+
+const adapter: PeggedIssuanceAdapter = {
+  ethereum: {
+    minted: ethereumMinted,
+    unreleased: async () => ({})
+  }
+};
+
+export default adapter;

--- a/src/adapters/peggedAssets/bean2/index.ts
+++ b/src/adapters/peggedAssets/bean2/index.ts
@@ -1,9 +1,0 @@
-const chainContracts = {
-  ethereum: {
-    issued: ["0xBEA0000029AD1c77D3d5D23Ba2D8893dB9d1Efab"],
-  },
-};
-
-import { addChainExports } from "../helper/getSupply";
-const adapter = addChainExports(chainContracts);
-export default adapter;

--- a/src/adapters/peggedAssets/index.ts
+++ b/src/adapters/peggedAssets/index.ts
@@ -66,7 +66,7 @@ import fusd from "./fantom-usd";
 import uxd from "./uxd-stablecoin";
 import usdh from "./usdh";
 import fpi from "./frax-price-index";
-import bean2 from "./bean2";
+import bean from "./bean";
 import usdlemma from "./usdlemma";
 //import pandousd from "./pando-usd";
 import dusd from "./digitaldollar";
@@ -261,7 +261,7 @@ export default {
   "uxd-stablecoin": uxd,
   usdh,
   "frax-price-index": fpi,
-  bean: bean2,
+  bean: bean,
   usdlemma,
   //"pando-usd": pandousd,
   digitaldollar: dusd,


### PR DESCRIPTION
- Modified the existing Bean adapter to include both v1 and v2 bean tokens. As a result, the token supply chart can now start on 8/6/22 instead of 8/5/23.

As a side-note wanted to mention a couple things for your reference:
- As part of the repo setup outlined in the readme, I needed an additional command after the second `npm i`. The command that fixed it for me was `npm install typescript@latest ts-node@latest`.
- There are 6 npm packages with critical vulnerabilities. I was able to develop in an isolated environment, though having to do so is certainly not ideal