### PR TITLE
Add USC to ETC

### DIFF
--- a/src/adapters/peggedAssets/classic-usd/index.ts
+++ b/src/adapters/peggedAssets/classic-usd/index.ts
@@ -1,0 +1,9 @@
+const chainContracts = {
+  ethereumclassic: {
+    issued: ["0xDE093684c796204224BC081f937aa059D903c52a"],
+  },
+};
+
+import { addChainExports } from "../helper/getSupply";
+const adapter = addChainExports(chainContracts);
+export default adapter;

--- a/src/adapters/peggedAssets/classic-usd/index.ts
+++ b/src/adapters/peggedAssets/classic-usd/index.ts
@@ -1,7 +1,12 @@
 const chainContracts = {
   ethereumclassic: {
     issued: ["0xDE093684c796204224BC081f937aa059D903c52a"],
+    pegType: 'peggedUSD',
   },
+  polygon: {
+    issued: ["0x131409b31bf446737dd04353d43dacada544b6fa"],
+    pegType: 'peggedUSD',
+  }
 };
 
 import { addChainExports } from "../helper/getSupply";

--- a/src/adapters/peggedAssets/index.ts
+++ b/src/adapters/peggedAssets/index.ts
@@ -192,6 +192,7 @@ import bitusd from "./bitsmiley-bitusd";
 import usda from "./angle-usd"
 import usc2  from "./usc-2";
 import ckusdc from "./ckusdc"
+import classicusd from "./classic-usd";
 
 export default {
   tether,
@@ -387,5 +388,6 @@ export default {
   "bitsmiley-bitusd": bitusd,
   "angle-usd": usda,
   "usc-2": usc2,
-  ckusdc //fakecg
+  ckusdc, //fakecg
+  "classic-usd": classicusd,
 };


### PR DESCRIPTION
Add USC to track TVL in ETCswap V3, the only regulated stablecoin on the Ethereum Classic network.

# classic-usd
A stablecoin for the Ethereum Classic network.

## smart contract address
* ethereum classic : [0xDE093684c796204224BC081f937aa059D903c52a](https://etc.blockscout.com/token/0xDE093684c796204224BC081f937aa059D903c52a)
* polygon : [0x131409b31bf446737dd04353d43dacada544b6fa](https://polygonscan.com/token/0x131409b31bf446737dd04353d43dacada544b6fa)

## properties
* name: Classic USD
* ticker: USC
* decimals: 6
* type: ERC-20
* short description: Launched in 2024, Classic USD (USC) is a fiat-collateralized stablecoin issued through a partnership between Brale and EthereumClassic.com. Classic USD is the premiere native stablecoin for Ethereum Classic’s decentralized finance ecosystem, global payments, and on-chain fiat settlement. As of 2022, Ethereum Classic is the largest and most secure Proof-of-Work smart contract network in the world.
* website: https://brale.xyz/stablecoins/USC
* DEX: https://etcswap.org
* screener: https://www.coingecko.com/coins/classic-usd

## visual assets

### 200x200
![png](https://github.com/white-b0x/classic-usd/raw/main/assets/usc-logo-200x200.png "png")
