### PR TITLE
Adapter and listing Usual USD

### DIFF
--- a/src/adapters/peggedAssets/index.ts
+++ b/src/adapters/peggedAssets/index.ts
@@ -191,7 +191,8 @@ import fxbtcusd from "./f-x-btc-usd";
 import bitusd from "./bitsmiley-bitusd";
 import usda from "./angle-usd"
 import usc2  from "./usc-2";
-import ckusdc from "./ckusdc"
+import ckusdc from "./ckusdc";
+import usd0 from "./usual-usd"
 
 export default {
   tether,
@@ -387,5 +388,6 @@ export default {
   "bitsmiley-bitusd": bitusd,
   "angle-usd": usda,
   "usc-2": usc2,
-  ckusdc //fakecg
+  ckusdc, //fakecg
+  "usual-usd": usd0
 };

--- a/src/adapters/peggedAssets/usual-usd/index.ts
+++ b/src/adapters/peggedAssets/usual-usd/index.ts
@@ -1,0 +1,8 @@
+const chainContracts = {
+    ethereum: {
+      issued: ["0x73A15FeD60Bf67631dC6cd7Bc5B6e8da8190aCF5"],
+    },
+  };
+  import { addChainExports } from "../helper/getSupply";
+  const adapter = addChainExports(chainContracts);
+  export default adapter;

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -3906,4 +3906,23 @@ export default [
     wiki: "https://github.com/dfinity/ic/blob/master/rs/ethereum/cketh/docs/ckerc20.adoc",
   },
   */
+  {
+    id: "195",
+    name: "Usual USD",
+    address: "0x73A15FeD60Bf67631dC6cd7Bc5B6e8da8190aCF5",
+    symbol: "USD0",
+    url: "https://usual.money",
+    description: "Usual enables an RWA-stablecoin that provides a high standard of security and transparency, while redistributing the generated value in the form of speculative yield in $USUAL, the Usual governance token.",
+    mintRedeemDescription:
+      "Usual enables users to deposit either USYC or USDC as collateral to mint USD0. USD0 is backed 1:1 by collateral exclusively in the form of very short-term RWAs (Real-World Assets).",
+    onCoinGecko: true,
+    gecko_id: "usual-usd",
+    cmcId: null,
+    pegType: "peggedUSD",
+    pegMechanism: "RWA-backed",
+    priceSource: "coingecko",
+    auditLinks: "https://gitbook.usual.money/ressources-and-ecosystem/audits",
+    twitter: "https://x.com/usualmoney",
+    wiki: "https://gitbook.usual.money/",
+  },
 ] as PeggedAsset[];

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -3915,7 +3915,7 @@ export default [
     description: "Usual enables an RWA-stablecoin that provides a high standard of security and transparency, while redistributing the generated value in the form of speculative yield in $USUAL, the Usual governance token.",
     mintRedeemDescription:
       "Usual enables users to deposit either USYC or USDC as collateral to mint USD0. USD0 is backed 1:1 by collateral exclusively in the form of very short-term RWAs (Real-World Assets).",
-    onCoinGecko: true,
+    onCoinGecko: false,
     gecko_id: "usual-usd",
     cmcId: null,
     pegType: "peggedUSD",


### PR DESCRIPTION
### Usual USD

chain: **Ethereum**
address: **0x73A15FeD60Bf67631dC6cd7Bc5B6e8da8190aCF5**
symbol: **USD0**
website: **https://usual.money**
twitter: **https://x.com/usualmoney**
wiki: **https://gitbook.usual.money**

Usual enables an RWA-stablecoin that provides a high standard of security and transparency, while redistributing the generated value in the form of speculative yield in $USUAL, the Usual governance token

On Usual users can deposit either USYC or USDC as collateral to mint USD0. USD0 is backed 1:1 by collateral exclusively in the form of very short-term RWAs (Real-World Assets)