### PR TITLE
listing Anzen USDz

### DIFF
--- a/src/adapters/peggedAssets/anzen-usdz/index.ts
+++ b/src/adapters/peggedAssets/anzen-usdz/index.ts
@@ -1,0 +1,18 @@
+const chainContracts = {
+    ethereum: {
+      issued: ["0xa469b7ee9ee773642b3e93e842e5d9b5baa10067"],
+    },
+    base: {
+      issued: ["0x04d5ddf5f3a8939889f11e97f8c4bb48317f1938"],
+    },
+    blast: {
+      issued: ["0x52056ed29fe015f4ba2e3b079d10c0b87f46e8c6"],
+    },
+    manta: {
+      issued: ["0x73d23f3778a90be8846e172354a115543df2a7e4"],
+    }
+  };
+  
+  import { addChainExports } from "../helper/getSupply";
+  const adapter = addChainExports(chainContracts);
+  export default adapter;

--- a/src/adapters/peggedAssets/index.ts
+++ b/src/adapters/peggedAssets/index.ts
@@ -199,6 +199,7 @@ import usr from "./resolv-usr";
 import ausd from "./stable-jack-ausd";
 import creal from "./celo-real-creal";
 import hexdc from "./hex-dollar-coin";
+import usdz from "./anzen-usdz";
 
 export default {
   tether,
@@ -401,5 +402,6 @@ export default {
   "stable-jack-ausd": ausd,
   "hedera-swiss-franc": hchf,
   "celo-real-creal": creal,
-  "hex-dollar-coin": hexdc
+  "hex-dollar-coin": hexdc,
+  "anzen-usdz": usdz
 };

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -4044,4 +4044,25 @@ export default [
     twitter: "https://x.com/POWERCITYio",
     wiki: "https://docs.powercity.io/flex-protocol",
   },
+  {
+    id: "202",
+    name: "Anzen USDz",
+    address: "0xa469b7ee9ee773642b3e93e842e5d9b5baa10067",
+    symbol: "USDz",
+    url: "https://anzen.finance/",
+    description:
+      "USDz is a stablecoin backed by a diversified portfolio of private credit assets, specifically over-collateralized asset-backed securities. These assets are rigorously underwritten in partnership with Percent, a US licensed broker-dealer that has structured and serviced over $1.7 billion in credit deals since 2018.",
+    mintRedeemDescription:
+      "Anzen enables users to deposit either SPCT as collateral to create USDz. The protocol deploys capital alongside institutional fiat investors, ensuring a robust and secure backing for USDz.",
+    onCoinGecko: "true",
+    gecko_id: "anzen-usdz",
+    cmcId: null,
+    pegType: "peggedUSD",
+    pegMechanism: "fiat-backed",
+    priceSource: "defillama",
+    auditLinks: 
+      "https://docs.anzen.finance/developer-resources/audits",
+    twitter: "https://x.com/AnzenFinance",
+    wiki: "https://docs.anzen.finance/",
+  },
 ] as PeggedAsset[];


### PR DESCRIPTION
Although Anzen only issue USDz on the mainnet, we uniformly use "issued" in this pr due to the cross-chain standard adopting the mint/burn model.


```
npx ts-node --transpile-only test.ts anzen-usdz peggedUSD

--- ethereum ---
minted                    4.99 M
circulating               4.99 M
unreleased                0
--- base ---
minted                    19.28 M
circulating               19.28 M
unreleased                0
--- blast ---
minted                    103.95 k
circulating               103.95 k
unreleased                0
--- manta ---
minted                    0.409
circulating               0.409
unreleased                0
------ Total Circulating ------
Total circulating         24.37 M
Total unreleased          0
```