### PR TITLE
feat: add M token by M^0 - https://m0.org

### DIFF
--- a/src/adapters/peggedAssets/index.ts
+++ b/src/adapters/peggedAssets/index.ts
@@ -209,7 +209,7 @@ import dckusd from "./dackie-usd";
 import skydollar from "./usds";
 import deusd from "./elixir-deusd";
 import thusd from "./threshold-usd"
-
+import m from "./m0-m"
 
 export default {
   tether,
@@ -422,5 +422,6 @@ export default {
   "dackie-usd": dckusd,
   "usds": skydollar,
   "elixir-deusd": deusd,
-  "threshold-usd": thusd
+  "threshold-usd": thusd,
+  "m-by-m0": m
 };

--- a/src/adapters/peggedAssets/m0-m/index.ts
+++ b/src/adapters/peggedAssets/m0-m/index.ts
@@ -1,0 +1,10 @@
+import { addChainExports } from "../helper/getSupply";
+
+const chainContracts = {
+    ethereum: {
+        issued: ["0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b"],
+    },
+};
+
+const adapter = addChainExports(chainContracts);
+export default adapter;


### PR DESCRIPTION
This PR adds the token M by [M^0](https://m0.org/)

M: https://etherscan.io/token/0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b

Supporting links
Official website: https://www.m0.org/
Whitepaper: https://docs.m0.org/portal
Twitter / X: https://x.com/m0foundation
Linkedin: https://linkedin.com/company/m0-labs