### PR TITLE
Add Ondo USDY on Mantra and Penumbra

### DIFF
--- a/src/adapters/peggedAssets/ondo-us-dollar-yield/index.ts
+++ b/src/adapters/peggedAssets/ondo-us-dollar-yield/index.ts
@@ -85,6 +85,12 @@ const adapter: PeggedIssuanceAdapter = {
   },
   osmosis: {
     noble: bridgedFromNoble("channel-1"),
+  },
+  mantra: {
+    noble: bridgedFromNoble("channel-101"),
+  },
+  penumbra: {
+    noble: bridgedFromNoble("channel-89"),
   }
 };
 


### PR DESCRIPTION
Ondo's USDY token has been bridged from Noble to 4 cosmos chains thru IBC:
- Mantra
- Injective
- Osmosis
- Penumbra