### PR TITLE
fix ronin usdc supply

### DIFF
--- a/src/adapters/peggedAssets/usd-coin/config.ts
+++ b/src/adapters/peggedAssets/usd-coin/config.ts
@@ -123,7 +123,8 @@ export const chainContracts: ChainContracts = {
     bridgedFromETH: ["0xcca4e6302510d555b654b3eab9c0fcb223bcfdf0"],
   },
   ronin: {
-    bridgedFromETH: ["0x0b7007c13325c48911f73a2dad5fa5dcbf808adc"],
+    bridgeOnETH: ["0x64192819ac13ef72bf6b5ae239ac672b43a9af08"],
+    issued: ["0x0b7007c13325c48911f73a2dad5fa5dcbf808adc"], 
   },
   aurora: {
     bridgeOnETH: ["0x23Ddd3e3692d1861Ed57EDE224608875809e127f"],

--- a/src/adapters/peggedAssets/usd-coin/index.ts
+++ b/src/adapters/peggedAssets/usd-coin/index.ts
@@ -645,7 +645,11 @@ const adapter: PeggedIssuanceAdapter = {
     ),
   },
   ronin: {
-    ethereum: bridgedSupply("ronin", 6, chainContracts.ronin.bridgedFromETH),
+    ethereum: supplyInEthereumBridge(
+      chainContracts.ethereum.issued[0],
+      chainContracts.ronin.bridgeOnETH[0],
+      6
+    )
   },
   aurora: {
     near: bridgedSupply("aurora", 6, chainContracts.aurora.bridgedFromNear),


### PR DESCRIPTION
Checking the total supply of the USDC contract on Ronin `0x0b7007c13325c48911f73a2dad5fa5dcbf808adc` won't give a correct information about bridged USDC on Ronin, because when the tokens are withdrawn to Ethereum they stay locked in the bridge contracts `0xe35d62ebe18413d96ca2a2f7cf215bb21a406b4b` and `0x0cf8ff40a508bdbc39fbe1bb679dcba64e65c7df` on Ronin.

Instead, we can just fetch the locked tokens from the Ethereum bridge contract. `0x64192819ac13ef72bf6b5ae239ac672b43a9af08`.