### PR TITLE
Update Viction info 

### DIFF
--- a/src/adapters/peggedAssets/tether/config.ts
+++ b/src/adapters/peggedAssets/tether/config.ts
@@ -98,7 +98,7 @@ export const chainContracts: ChainContracts = {
     bridgedFromETH: ["0xB44a9B6905aF7c801311e8F4E76932ee959c663C"], // multichain
   },
   tomochain: {
-    bridgedFromETH: ["0x381b31409e4d220919b2cff012ed94d70135a59e"],
+    bridgedFromETH: ["0x69b946132b4a6c74cd29ba3ff614ceea1ef9ff2b"],
   },
   harmony: {
     bridgeOnETH: ["0x2dccdb493827e15a5dc8f8b72147e6c4a5620857"],

--- a/src/peggedData/bridgeData.ts
+++ b/src/peggedData/bridgeData.ts
@@ -1805,8 +1805,8 @@ export const bridgeInfo = {
     link: "https://voltage.finance/",
   },
   tomochain: {
-    name: "TomoBridge",
-    link: "https://bridge.TomoChain.com/",
+    name: "Arken Bridge",
+    link: "https://arken.ag/bridge",
   },
   evodefi: {
     name: "EVODeFi",

--- a/src/utils/normalizeChain.ts
+++ b/src/utils/normalizeChain.ts
@@ -416,7 +416,7 @@ export const chainCoingeckoIds = {
   },
   TomoChain: {
     geckoId: "tomochain",
-    symbol: "TOMO",
+    symbol: "VIC",
     cmcId: "2570",
     categories: ["EVM"],
     chainId: 88,

--- a/src/utils/normalizeChain.ts
+++ b/src/utils/normalizeChain.ts
@@ -1191,7 +1191,7 @@ export function getChainDisplayName(
     case "gochain":
       return "GoChain";
     case "tomochain":
-      return "TomoChain";
+      return "Viction";
     case "fusion":
       return "Fusion";
     case "kardia":


### PR DESCRIPTION
Hi, I would like to request update the information for Viction chain on Stable Page:

1. Update chain display name from `TomoChain` to `Viction`
2. Update the official USDT to the new one which is `0x69b946132b4a6c74cd29ba3ff614ceea1ef9ff2b`. please verify here > https://x.com/BuildOnViction/status/1871178874685648919
3. Update the symbol from `TOMO` to `VIC`. Please check > https://www.coingecko.com/en/coins/viction
4. Update bridge protocol to the new one

Thank you!