### PR TITLE
Add Level USD

### DIFF
--- a/src/adapters/peggedAssets/index.ts
+++ b/src/adapters/peggedAssets/index.ts
@@ -223,7 +223,8 @@ import zkusd from "./zkusd";
 import dtrinityusd from "./dtrinity-usd";
 import zeusd from "./zoth-zeusd";
 import zchf from "./frankencoin";
-import bold from "./liquity-bold"
+import bold from "./liquity-bold";
+import lvlusd from "./level-usd";
 
 export default {
   tether,
@@ -433,24 +434,25 @@ export default {
   "balanced-dollars": bnusd,
   "agora-dollar": ausdagora,
   "opus-cash": opuscash,
-  "dyad": dyad,
+  dyad: dyad,
   "dackie-usd": dckusd,
-  "usds": skydollar,
+  usds: skydollar,
   "elixir-deusd": deusd,
   "threshold-usd": thusd,
   "move-dollar": mod,
   "usdx-money-usdx": usdx0,
   "m-by-m^0": m,
-  "moneta": moneta,
+  moneta: moneta,
   "solayer-usd": solayerusd,
   "reservoir-stablecoin": rusd1,
   "satoshi-stablecoin": satusd,
   "astherus-usdf": usdf,
   "usda-2": avalon_usda, // coingecko id first, than token
-  usdtb,  // same as coingeckoID,
- "tren-debt-token" : xy,
- "dtrinity-usd": dtrinityusd,
- "zoth-zeusd": zeusd,
- "frankencoin": zchf,
- "liquity-bold": bold
+  usdtb, // same as coingeckoID,
+  "tren-debt-token": xy,
+  "dtrinity-usd": dtrinityusd,
+  "zoth-zeusd": zeusd,
+  frankencoin: zchf,
+  "liquity-bold": bold,
+  "level-usd": lvlusd,
 };

--- a/src/adapters/peggedAssets/level-usd/index.ts
+++ b/src/adapters/peggedAssets/level-usd/index.ts
@@ -1,0 +1,10 @@
+import { addChainExports } from "../helper/getSupply";
+
+const chainContracts = {
+  ethereum: {
+    issued: ["0x7c1156e515aa1a2e851674120074968c905aaf37"],
+  },
+};
+
+const adapter = addChainExports(chainContracts);
+export default adapter;


### PR DESCRIPTION
Hey team! Here's the metadata we'd like to add to our listing for Level USD onto the stablecoin page.

_Name_: Level USD
_Symbol_: `lvlUSD`
_Icon_: https://storage.googleapis.com/level-public/icons/lvlusd.svg
_Website_: https://level.money
_Twitter_: https://twitter.com/levelusd

_Description_
Level USD is a stablecoin backed by USDC and USDT that are deployed on blue-chip restaking and lending protocols. Users can stake Level USD to earn stacked restaking and lending yield with the stable reserves of battle-tested stablecoins.

Category: crypto-backed

_Minting and Redemption_
Users can mint Level USD with USDC and USDT permissionlessly. The protocol deploys this collateral into blue-chip restaking and lending protocols to generate yield for users.