### PR TITLE
Add EURCV (Euro Coinvertible) adapter

### DIFF
--- a/src/adapters/peggedAssets/eur-coinvertible/config.ts
+++ b/src/adapters/peggedAssets/eur-coinvertible/config.ts
@@ -1,0 +1,12 @@
+import {ChainContracts} from "../peggedAsset.type";
+
+export const chainContracts: ChainContracts = {
+    ethereum: {
+        issued: ["0x5F7827FDeb7c20b443265Fc2F40845B715385Ff2"],
+        unreleased: ["0xc98Cb9F53e20AFbbeb75Caf6456eD52D5d7903f6", "0x7dE0bbdfCd4A6a956F149bEFcca30D6B5Bc5DA69"], // Operation registrar
+    },
+    solana: {
+        issued: ["DghpMkatCiUsofbTmid3M3kAbDTPqDwKiYHnudXeGG52"], // mainnet token
+        unreleased: ["4N1WwAaSukn7YtRKRArA3Ntp4CfcB1nCiqCDGEjEBhEj", "5tg4qRdiXJ7XxYd6KK4UnnNvxgHJqfBUygPqZLwSnhnt"], // Operation registrar
+    }
+}

--- a/src/adapters/peggedAssets/eur-coinvertible/index.ts
+++ b/src/adapters/peggedAssets/eur-coinvertible/index.ts
@@ -1,0 +1,107 @@
+const sdk = require("@defillama/sdk");
+import {Balances, ChainBlocks, PeggedAssetType, PeggedIssuanceAdapter} from "../peggedAsset.type";
+import {chainContracts} from "../eur-coinvertible/config";
+import {getTokenBalance as solanaGetTokenBalance, getTokenSupply as solanaGetTokenSupply} from "../helper/solana";
+import {sumSingleBalance} from "../helper/generalUtil";
+
+
+async function chainMinted(chain: string, decimals: number) {
+    return async function (
+        _timestamp: number,
+        _ethBlock: number,
+        _chainBlocks: ChainBlocks
+    ) {
+        let balances = {} as Balances;
+        for (let issued of chainContracts[chain].issued) {
+            const totalSupply = (
+                await sdk.api.abi.call({
+                    abi: "erc20:totalSupply",
+                    target: issued,
+                    block: _chainBlocks?.[chain],
+                    chain: chain,
+                })
+            ).output;
+            sumSingleBalance(
+                balances,
+                "peggedEUR",
+                totalSupply / 10 ** decimals,
+                "issued",
+                false
+            );
+        }
+        return balances;
+    };
+}
+
+async function chainUnreleased(chain: string, decimals: number, owner: string) {
+    return async function (
+        _timestamp: number,
+        _ethBlock: number,
+        _chainBlocks: ChainBlocks
+    ) {
+        let balances = {} as Balances;
+        for (let issued of chainContracts[chain].issued) {
+            const reserve = (
+                await sdk.api.erc20.balanceOf({
+                    target: issued,
+                    owner: owner,
+                    block: _chainBlocks?.[chain],
+                    chain: chain,
+                })
+            ).output;
+            sumSingleBalance(balances, "peggedEUR", reserve / 10 ** decimals, "issued", false);
+        }
+        return balances;
+    };
+}
+
+export function solanaMintedOrBridged(
+    targets: string[]
+) {
+    return async function (
+        _timestamp: number,
+        _ethBlock: number,
+        _chainBlocks: ChainBlocks
+    ) {
+        let balances = {} as Balances;
+        for (let target of targets) {
+            const totalSupply = await solanaGetTokenSupply(target);
+            sumSingleBalance(balances, "peggedEUR", totalSupply, target, false);
+        }
+        return balances;
+    };
+}
+
+async function solanaUnreleased() {
+    return async function (
+        _timestamp: number,
+        _ethBlock: number,
+        _chainBlocks: ChainBlocks
+    ) {
+        let balances = {} as Balances;
+        for (let unreleasedAddress of chainContracts["solana"].unreleased) {
+            sumSingleBalance(balances, "peggedEUR", await solanaGetTokenBalance(
+                chainContracts["solana"].issued[0],
+                unreleasedAddress
+            ),unreleasedAddress, false);
+        }
+        return balances;
+    };
+}
+
+const adapter: PeggedIssuanceAdapter = {
+    ethereum: {
+        minted: chainMinted("ethereum", 18),
+        unreleased: chainUnreleased(
+            "ethereum",
+            18,
+            chainContracts.ethereum.unreleased[0]
+        ),
+    },
+    solana: {
+        minted: solanaMintedOrBridged(chainContracts.solana.issued),
+        unreleased: solanaUnreleased()
+    },
+}
+
+export default adapter;

--- a/src/adapters/peggedAssets/index.ts
+++ b/src/adapters/peggedAssets/index.ts
@@ -248,6 +248,7 @@ import cardano_usda from './anzens-usda';
 import usdfc from './usdfc';
 import rlusd from './ripple-usd';
 import feusd from './felix-feusd';
+import eurcv from "./eur-coinvertible";
 import standx_dusd from './standx-dusd';
 
 export default {
@@ -501,6 +502,7 @@ export default {
   "hashnote-usyc": hashnote_usyc,
   "usdfc": usdfc,
   "ripple-usd": rlusd,
+  "eur-coinvertible": eurcv,
   "felix-feusd": feusd,
   'standx-dusd': standx_dusd
 };


### PR DESCRIPTION
Integrates Euro Coinvertible (EURCV) into the pegged assets adapters. This includes support for issuance and unreleased tracking on Ethereum and Solana chains, along with the necessary configurations and helper functions.