### PR TITLE
feat: publish USDN token supply in stablecoin

### DIFF
--- a/src/adapters/peggedAssets/smardex-usdn/index.ts
+++ b/src/adapters/peggedAssets/smardex-usdn/index.ts
@@ -1,0 +1,37 @@
+const sdk = require("@defillama/sdk");
+import {
+  ChainBlocks,
+  PeggedIssuanceAdapter,
+} from "../peggedAsset.type";
+
+const chainContracts = {
+    ethereum: {
+      issued: "0xde17a000ba631c5d7c2bd9fb692efea52d90dee2",
+    },
+};
+
+async function usdnMinted() {
+return async function (
+    _timestamp: number,
+    _ethBlock: number,
+    _chainBlocks: ChainBlocks
+) {
+    const totalSupply = (
+      await sdk.api.abi.call({
+        abi: "erc20:totalSupply",
+        target: chainContracts.ethereum.issued,
+        block: _ethBlock,
+        chain: "ethereum",
+      })
+    ).output;
+    return { peggedUSD: totalSupply / 10 ** 18 };
+  };
+}
+
+const adapter: PeggedIssuanceAdapter = {
+  ethereum: {
+    minted: usdnMinted(),
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
{
name: "SMARDEX USDN",
address: "0xde17a000ba631c5d7c2bd9fb692efea52d90dee2",
symbol: "USDN",
url: "https://etherscan.io/token/0xde17a000ba631c5d7c2bd9fb692efea52d90dee2",
description: "The USDN token is the first synthetic U.S. dollar backed by a structured product utilizing a delta-Neutral strategy. Unlike traditional stablecoins, whose value is guaranteed by centralized entities, the value of a synthetic dollar is determined by a purely mathematical financial process.",
mintRedeemDescription: "Deposit Lido token (WSTETH) in USDN Vault allows to Mint USDN tokens and profit from its yield. Redeem Lido burns USDN",
onCoinGecko: "true",
gecko_id: "smardex-usdn",
cmcId: "smardex-usdn",
pegType: "peggedUSD",
pegMechanism: "crypto-backed",
priceSource: "defillama",
auditLinks: ["https://docs.smardex.io/ultimate-synthetic-delta-neutral/audits"],
twitter: "https://x.com/SmarDex/status/1882472789514551634",
parentProtocol: "smardex",
},