### PR TITLE
Add Multi-Chain Support and Update WEUSD Adapter & Description

### DIFF
--- a/src/adapters/peggedAssets/weusd/index.ts
+++ b/src/adapters/peggedAssets/weusd/index.ts
@@ -1,4 +1,4 @@
-// import { addChainExports } from "../helper/getSupply";
+import { addChainExports } from "../helper/getSupply";
 import { PeggedIssuanceAdapter, Balances } from "../peggedAsset.type";
 import { function_view } from "../helper/aptos";
 
@@ -18,23 +18,20 @@ async function movementSupply(): Promise<Balances> {
   return balances;
 }
 
-// const chainContracts = {
-//   ethereum: {
-//     issued: ["0xcacd6fd266af91b8aed52accc382b4e165586e29"],
-//   },
-//   base: {
-//     issued: "0x80eede496655fb9047dd39d9f418d5483ed600df",
-//   },
-//   arbitrum: {
-//     issued: "0x80eede496655fb9047dd39d9f418d5483ed600df",
-//   },
-//   bsc: {
-//     issued: "0x80eede496655fb9047dd39d9f418d5483ed600df",
-//   },
-// };
+const chainContracts = {
+  base: {
+    issued: "0xdd73EA766B80417C0607A3f08E34A0C415D89D56",
+  },
+  arbitrum: {
+    issued: "0xdd73EA766B80417C0607A3f08E34A0C415D89D56",
+  },
+  bsc: {
+    issued: "0xdd73EA766B80417C0607A3f08E34A0C415D89D56",
+  },
+};
 
 const adapter: PeggedIssuanceAdapter = {
-  // ...addChainExports(chainContracts),
+  ...addChainExports(chainContracts),
   move: {
     minted: movementSupply,
   }

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -5553,7 +5553,7 @@ export default [
     coin_icon: "https://raw.githubusercontent.com/pipimove/logo/refs/heads/main/coin_weusd.ico",
     url: "https://picwe.org",
     description:
-      "WEUSD is a USD stablecoin built on the Movement blockchain that maintains a 1:1 peg to USD. This stablecoin provides stable value storage and exchange medium for the Movement ecosystem.",
+      "$WEUSD is a key component of PicWe’s ecosystem, designed to provide stability and facilitate efficient, reliable cross-chain transactions. As a native decentralized stablecoin, $WEUSD is created on-chain via smart contracts and plays a critical role in PicWe’s Omni-chain asset settlement layer.",
     mintRedeemDescription:
       "Users can mint WEUSD by depositing USDT/USDC assets.",
     onCoinGecko: "false",


### PR DESCRIPTION
# PR: Add Multi-Chain Support and Update WEUSD Adapter & Description

## Summary

This PR uncomments and updates the `chainContracts` object in the WEUSD adapter to support new contract addresses for the `base`, `arbitrum`, and `bsc` chains. It also enables `addChainExports` in the adapter to include these chains, and updates the project description for WEUSD to reflect multi-chain deployment.

---

## Changes

### 1. Multi-Chain Support in `chainContracts`
- **Added chains:** `base`, `arbitrum`, `bsc`
- **Contract address for all chains:**  
  `0xdd73EA766B80417C0607A3f08E34A0C415D89D56`
- **Purpose:** Enables WEUSD supply tracking across multiple chains for more comprehensive analytics.

### 2. Adapter Export Enhancement
- The adapter now uses `addChainExports(chainContracts)` to ensure all supported chains are included in the exported object, making the data available to the API and frontend.

### 3. Updated WEUSD Project Description (for `peggedData/peggedData.ts`)


---

## Impact

- Enables multi-chain supply tracking for WEUSD
- Ensures adapter exports are up-to-date and accurate
- Improves project documentation for aggregator platforms like DefiLlama

---

## Checklist

- [x] Contract addresses are correct
- [x] Adapter exports all supported chains
- [x] Project description/documentation updated
- [x] Local tests pass



