### PR TITLE
Add Noble Dollar (USDN) adapter

### DIFF
--- a/src/adapters/peggedAssets/index.ts
+++ b/src/adapters/peggedAssets/index.ts
@@ -276,6 +276,7 @@ import ylds from './ylds';
 import usdn from './smardex-usdn';
 import weusd from './weusd';
 import parausd from './parabol-usd';
+import noble_dollar_usdn from "./noble-dollar-usdn";
 
 export default {
   tether,
@@ -556,5 +557,6 @@ export default {
   "ylds": ylds,
   "smardex-usdn": usdn,
   "weusd": weusd,
-  "parabol-usd": parausd
+  "parabol-usd": parausd,
+  "noble-dollar-usdn": noble_dollar_usdn,
 };

--- a/src/adapters/peggedAssets/noble-dollar-usdn/index.ts
+++ b/src/adapters/peggedAssets/noble-dollar-usdn/index.ts
@@ -1,0 +1,21 @@
+import { cosmosSupply } from "../helper/getSupply";
+import { PeggedIssuanceAdapter } from "../peggedAsset.type";
+
+function nobleSupply() {
+  return cosmosSupply(
+    "noble",           // chain name
+    ['uusdn'],         // token denomination 
+    6,                 // decimals
+    '',                // prefix
+    'peggedUSD'        // peg type
+  );
+}
+
+const adapter: PeggedIssuanceAdapter = {
+  noble: {
+    minted: nobleSupply(),
+    unreleased: async () => ({}), // no unreleased tokens
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
Add adapter for Noble Dollar (USDN).

- Token: Noble Dollar (USDN)
- Chain: Noble 
- Denomination: uusdn
- Decimals: 6
- CoinGecko ID: noble-dollar-usdn