### PR TITLE
Add plume and hashkey chains to WEUSD adapter

### DIFF
--- a/src/adapters/peggedAssets/weusd/index.ts
+++ b/src/adapters/peggedAssets/weusd/index.ts
@@ -28,6 +28,12 @@ const chainContracts = {
   bsc: {
     issued: "0xdd73EA766B80417C0607A3f08E34A0C415D89D56",
   },
+  plume: {
+    issued: "0xdd73EA766B80417C0607A3f08E34A0C415D89D56",
+  },
+  hashkey: {
+    issued: "0xdd73EA766B80417C0607A3f08E34A0C415D89D56",
+  },
 };
 
 const adapter: PeggedIssuanceAdapter = {


### PR DESCRIPTION
Added support for the 'plume' and 'hashkey' chains in the WEUSD pegged asset adapter, using the same issued contract address as other chains.