### PR TITLE
feat: update peggedAssets, new chains and minted/issued configurations

### DIFF
--- a/src/adapters/peggedAssets/frankencoin/index.ts
+++ b/src/adapters/peggedAssets/frankencoin/index.ts
@@ -12,19 +12,30 @@ const chainContracts: ChainContracts = {
     issued: ["0xB58E61C3098d85632Df34EecfB899A1Ed80921cB"],
   },
   polygon: {
+    issued: ["0xD4dD9e2F021BB459D5A5f6c24C12fE09c5D45553"],
     bridgedFromETH: ["0x02567e4b14b25549331fCEe2B56c647A8bAB16FD"], 
   },
   arbitrum: {
+    issued: ["0xD4dD9e2F021BB459D5A5f6c24C12fE09c5D45553"],
     bridgedFromETH: ["0xB33c4255938de7A6ec1200d397B2b2F329397F9B"], 
   },
   optimism: {
+    issued: ["0xD4dD9e2F021BB459D5A5f6c24C12fE09c5D45553"],
     bridgedFromETH: ["0x4F8a84C442F9675610c680990EdDb2CCDDB8aB6f"], 
   },
   base: {
+    issued: ["0xD4dD9e2F021BB459D5A5f6c24C12fE09c5D45553"],
     bridgedFromETH: ["0x20D1c515e38aE9c345836853E2af98455F919637"], 
   },
   xdai: { // gnosis chain
+    issued: ["0xD4dD9e2F021BB459D5A5f6c24C12fE09c5D45553"],
     bridgedFromETH: ["0x4cde2b4e7254e6ec5b450d50e3607bade6be3980"], 
+  },
+  avax: { // avalanche chain
+    issued: ["0xD4dD9e2F021BB459D5A5f6c24C12fE09c5D45553"],
+  },
+  sonic: {
+    issued: ["0xD4dD9e2F021BB459D5A5f6c24C12fE09c5D45553"],
   },
 };
 
@@ -61,6 +72,7 @@ const adapter: PeggedIssuanceAdapter = {
     minted: chainMinted("ethereum", 18),
   },
   polygon: {
+    minted: chainMinted("polygon", 18),
     ethereum: bridgedSupply(
       "polygon",
       18,
@@ -71,6 +83,7 @@ const adapter: PeggedIssuanceAdapter = {
     )
   },
   arbitrum: {
+    minted: chainMinted("arbitrum", 18),
     ethereum: bridgedSupply(
       "arbitrum",
       18,
@@ -81,6 +94,7 @@ const adapter: PeggedIssuanceAdapter = {
     )
   },
   optimism: {
+    minted: chainMinted("optimism", 18),
     ethereum: bridgedSupply(
       "optimism",
       18,
@@ -91,6 +105,7 @@ const adapter: PeggedIssuanceAdapter = {
     )
   },
   base: {
+    minted: chainMinted("base", 18),
     ethereum: bridgedSupply(
       "base",
       18,
@@ -101,6 +116,7 @@ const adapter: PeggedIssuanceAdapter = {
     )
   },
   xdai: {
+    minted: chainMinted("xdai", 18),
     ethereum: bridgedSupply(
       "xdai",
       18,
@@ -109,6 +125,12 @@ const adapter: PeggedIssuanceAdapter = {
       "Ethereum",
       "peggedCHF"
     )
+  },
+  avax: {
+    minted: chainMinted("avax", 18),
+  },
+  sonic: {
+    minted: chainMinted("sonic", 18),
   },
 };
 


### PR DESCRIPTION
## Test Output

```
❯ npx ts-node test frankencoin/index.ts peggedCHF
--- ethereum ---
minted                    11.18 M
circulating               11.01 M
unreleased                0
--- polygon ---
circulating               126.97 k
ethereum                  125.95 k
minted                    1.02 k
unreleased                0
--- arbitrum ---
circulating               1.87 k
minted                    1.00 k
ethereum                  867.8571223817959
unreleased                0
--- optimism ---
circulating               40.71 k
ethereum                  39.71 k
minted                    1.00 k
unreleased                0
--- base ---
circulating               1.14 k
minted                    1.00 k
ethereum                  138
unreleased                0
--- xdai ---
circulating               1.00 k
minted                    1.00 k
ethereum                  1
unreleased                0
--- avax ---
minted                    1.00 k
circulating               1.00 k
unreleased                0
--- sonic ---
minted                    1
circulating               1
unreleased                0
------ Total Circulating ------
Total circulating         11.19 M
Total unreleased          0
┌─────────┬─────────────────────┬───────────┬─────────────┬────────────┬─────────────────────┐
│ (index) │ chain               │ minted    │ circulating │ unreleased │ ethereum            │
├─────────┼─────────────────────┼───────────┼─────────────┼────────────┼─────────────────────┤
│ 0       │ 'ethereum'          │ '11.18 M' │ '11.01 M'   │ '0'        │                     │
│ 1       │ 'polygon'           │ '1.02 k'  │ '126.97 k'  │ '0'        │ '125.95 k'          │
│ 2       │ 'arbitrum'          │ '1.00 k'  │ '1.87 k'    │ '0'        │ '867.8571223817959' │
│ 3       │ 'optimism'          │ '1.00 k'  │ '40.71 k'   │ '0'        │ '39.71 k'           │
│ 4       │ 'base'              │ '1.00 k'  │ '1.14 k'    │ '0'        │ '138'               │
│ 5       │ 'xdai'              │ '1.00 k'  │ '1.00 k'    │ '0'        │ '1'                 │
│ 6       │ 'avax'              │ '1.00 k'  │ '1.00 k'    │ '0'        │                     │
│ 7       │ 'sonic'             │ '1'       │ '1'         │ '0'        │                     │
│ 8       │ 'Total Circulating' │           │ '11.19 M'   │ '0'        │                     │
└─────────┴─────────────────────┴───────────┴─────────────┴────────────┴─────────────────────┘
```