### PR TITLE
Adding msUSD as a pegged asset

### DIFF
--- a/src/adapters/peggedAssets/main-street-usd/index.ts
+++ b/src/adapters/peggedAssets/main-street-usd/index.ts
@@ -1,0 +1,9 @@
+const chainContracts = {
+  sonic: {
+    issued: ["0xE5Fb2Ed6832deF99ddE57C0b9d9A56537C89121D"],
+  },
+};
+
+import { addChainExports } from "../helper/getSupply";
+const adapter = addChainExports(chainContracts);
+export default adapter;


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.


---
(fill in below form only for new listings)

##### Name (to be shown on DefiLlama): 

Mainstreet USD (msUSD)


##### Website Link:

https://mainstreet.finance/


##### Logo (High resolution, will be shown with rounded borders):

https://drive.google.com/file/d/1t4IEzGHvgH2Ok9eqY702JNElf5_rnzwo/view?usp=sharing


##### Chain: Sonic


##### Coingecko ID (leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

https://www.coingecko.com/en/coins/main-street-usd

##### Coinmarketcap ID (leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description:

Yield-bearing synthetic dollar - democratizing access to the options volatility arbitrage

##### mintRedeemDescription:

msUSD can be minted at https://mainstreet.finance/mint by depositing USDC. The depositor will be minted 1:1 msUSD. Redemptions can occur on the same UI.


##### Token address and ticker:

https://sonicscan.org/address/0xE5Fb2Ed6832deF99ddE57C0b9d9A56537C89121D

$msUSD


##### pegType: peggedUSD

##### pegMechanism: crypto backed

##### priceSource: defillama

##### wiki: https://mainstreet-finance.gitbook.io/mainstreet.finance

##### Twitter Link: https://x.com/Main_St_Finance


##### List of audit links if any: https://mainstreet-finance.gitbook.io/mainstreet.finance/audits/watchpug-security-audit