### PR TITLE
Hide Coingecko feed

### DIFF
--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -5180,7 +5180,7 @@ export default [
     url: "https://a7a5.io/",
     description: "A7A5 is a RUB stablecoin, fully backed by real assets and integrated into the Tron and Ethereum ecosystem. The main goal is to provide crypto enthusiasts with a safe and transparent tool for trading and passive income",
     mintRedeemDescription: "Users mint A7A5 by depositing Russian rubles through authorized partners with KYC, receiving tokens 1:1 on-chain, and can redeem them by returning A7A5 for an equivalent ruble payout",
-    onCoinGecko: "true",
+    onCoinGecko: "false",
     gecko_id: "a7a5",
     cmcId: "36549",
     pegType: "peggedRUB",


### PR DESCRIPTION
Correct price LP:

https://app.uniswap.org/explore/pools/ethereum/0x14d7aab5b4bca6a02e52ac22520b033bf35f4091

Coingecko is broken.

CMC price feed is correct:
https://coinmarketcap.com/currencies/a7a5/