### PR TITLE
XSY: Adds UTY for listing

### DIFF
--- a/src/adapters/peggedAssets/index.ts
+++ b/src/adapters/peggedAssets/index.ts
@@ -301,6 +301,7 @@ import jigsaw_usd from './jigsaw-usd';
 import mezousd from './mezo-usd'
 import hylo_hyusd from './hylo-hyusd';
 import usduFinance from './usdu';
+import xsy_uty from './uty';
 
 export default {
   tether,
@@ -607,4 +608,5 @@ export default {
   "mezo-usd": mezousd,
   "hylo-hyusd": hylo_hyusd,
   "usdu": usduFinance,
+  "xsy-uty": xsy_uty
 };

--- a/src/adapters/peggedAssets/unity-2/index.ts
+++ b/src/adapters/peggedAssets/unity-2/index.ts
@@ -1,0 +1,12 @@
+import { addChainExports } from '../helper/getSupply'
+import { PeggedIssuanceAdapter } from '../peggedAsset.type'
+
+const chainContracts = {
+  avax: {
+    issued: ['0xDBc5192A6B6FfEe7451301bb4ec312f844F02B4A'], // UTY
+  }
+}
+
+const adapter: PeggedIssuanceAdapter = addChainExports(chainContracts)
+
+export default adapter

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -6064,6 +6064,26 @@ export default [
     auditLinks: "https://usdu.finance/wp-content/uploads/2025/07/BlockBite-USDU-Security-Audit-2025.pdf",
     twitter: "https://x.com/USDUfinance",
     wiki: "https://usdu.gitbook.io/docs/",
-  }
+  },
+  {
+    id: "305",
+    name: "XSY UTY",
+    address: "0xDBc5192A6B6FfEe7451301bb4ec312f844F02B4A",
+    symbol: "UTY",
+    url: "https://xsy.fi",
+    description:
+      "A delta-neutral asset and serves as the synthetic dollar at the center of XSY's ecosystem of decentralized financial products.",
+    mintRedeemDescription:
+      "XSY enables users to deposit USDC or USDT to mint UTY. Stability is secured through delta-neutral hedging strategies.",
+    onCoinGecko: "true",
+    gecko_id: "unity-2",
+    cmcId: null,
+    pegType: "peggedUSD",
+    pegMechanism: "crypto-backed",
+    priceSource: "coingecko",
+    auditLinks: ["https://xsy-1.gitbook.io/xsy-main/audits"],
+    twitter: "https://x.com/xsy_fi",
+    wiki: "https://xsy.fi",
+  },
 
 ] as PeggedAsset[];


### PR DESCRIPTION
##### Name: 
UTY

##### Website Link:
https://xsy.fi

##### Logo:
![xsy](https://github.com/user-attachments/assets/84c2577a-ff19-4989-b493-0e0efaffed00)

##### Chain: Avalanche C-Chain

##### Coingecko ID: unity-2

##### Coinmarketcap ID:


##### Short Description: A delta-neutral asset and serves as the synthetic dollar at the center of XSY's ecosystem of decentralized financial products.

##### mintRedeemDescription: XSY enables users to deposit USDC or USDT to mint UTY. Stability is secured through delta-neutral hedging strategies.

##### Token address and ticker: UTY (`0xDBc5192A6B6FfEe7451301bb4ec312f844F02B4A`)


##### pegType: `peggedUSD`

##### pegMechanism: `crypto-backed`

##### priceSource: coingecko

##### wiki: https://xsy.fi

##### Twitter Link: https://x.com/xsy_fi


##### List of audit links if any: https://xsy-1.gitbook.io/xsy-main/audits