### PR TITLE
create tgbp

### DIFF
--- a/src/adapters/peggedAssets/tgbp/index.ts
+++ b/src/adapters/peggedAssets/tgbp/index.ts
@@ -1,0 +1,24 @@
+const chainContracts = {
+    ethereum: {
+      issued: ["0x27f6c8289550fCE67f6B50BeD1F519966aFE5287"],
+    },
+    bsc: {
+      issued: ["0x27f6c8289550fCE67f6B50BeD1F519966aFE5287"],
+    },
+    base: {
+      issued: ["0x27f6c8289550fCE67f6B50BeD1F519966aFE5287"],
+    },
+    polygon: {
+      issued: ["0x27f6c8289550fCE67f6B50BeD1F519966aFE5287"],
+    },
+    avax: {
+      issued: ["0x27f6c8289550fCE67f6B50BeD1F519966aFE5287"],
+    },
+    solana: {
+      issued: ["2zMqyX4AYCk6mgy5UZ2S7zUaLxwERhK5WjqDzkPPbSpW"],
+    },
+  };
+  
+  import { addChainExports } from "../helper/getSupply";
+  const adapter = addChainExports(chainContracts, undefined, { pegType: "peggedGBP" });
+  export default adapter;


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.


---
(fill in below form only for new listings)

##### Name (to be shown on DefiLlama): Tokenised GBP (tGBP)


##### Website Link: https://www.tokenisedgbp.com/


##### Logo (High resolution, will be shown with rounded borders): https://fv7sk7rtg6fk6qygptrs2smdepv6zeythjmn6xwj7z63yv64u5sq.arweave.net/LX8lfjM3iq9DBnzjLUmDI-vskxM6WN9eyf59vFfcp2U


##### Chain: Ethereum, Base, Avalanche, BSC, Polygon, Solana


##### Coingecko ID (leave empty if not listed): 


##### Coinmarketcap ID (leave empty if not listed): 


##### Short Description: Tokenised GBP (tGBP) is the only British Pound backed stablecoin issued by a UK FCA-registered firm. tGBP is fully backed with cash and short-term UK gilts and pegged 1:1 with the British Pound

##### mintRedeemDescription:
To mint Tokenised GBP (tGBP), eligible businesses need to create a tGBP Mint account and complete the required KYB and AML checks. Once the account is approved, businesses can mint and redeem tGBP with GBP from their UK bank account. Retail users can access mint and redemption services through a variety of exchange and payment partners

##### Token address and ticker:
0x27f6c8289550fce67f6b50bed1f519966afe5287 (tGBP)

##### pegType: fiat-backed

##### pegMechanism:

##### priceSource:

##### wiki:

##### Twitter Link: https://x.com/tokenGBP


##### List of audit links if any: https://www.openzeppelin.com/news/tgbp-audit