### PR TITLE
Added Ethereum chain to pUSD stablecoin

### DIFF
--- a/src/adapters/peggedAssets/plume-usd/index.ts
+++ b/src/adapters/peggedAssets/plume-usd/index.ts
@@ -3,6 +3,10 @@ const chainContracts = {
     issued: ["0xdddD73F5Df1F0DC31373357beAC77545dC5A6f3F"],
     pegType: "peggedUSD",
   },
+  ethereum: {
+    issued: ["0xdddD73F5Df1F0DC31373357beAC77545dC5A6f3F"],
+    pegType: "peggedUSD",
+  },
 };
 
 import { addChainExports } from "../helper/getSupply";


### PR DESCRIPTION
Added Ethereum chain to pUSD stablecoin

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.


---
(fill in below form only for new listings)

##### Name (to be shown on DefiLlama): 
Ethereum

##### Website Link:


##### Logo (High resolution, will be shown with rounded borders):


##### Chain:
Ethereum

##### Coingecko ID (leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)
https://www.coingecko.com/en/coins/plume-usd

##### Coinmarketcap ID (leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description:

##### mintRedeemDescription:


##### Token address and ticker:
0xdddD73F5Df1F0DC31373357beAC77545dC5A6f3F, pUSD

##### pegType:
peggedUSD
##### pegMechanism:

##### priceSource:

##### wiki:

##### Twitter Link:


##### List of audit links if any: