### PR TITLE
Added BSC and Tron chain for PUSD

### DIFF
--- a/src/adapters/peggedAssets/pusd/index.ts
+++ b/src/adapters/peggedAssets/pusd/index.ts
@@ -5,6 +5,9 @@ const chainContracts = {
     binance: {
         issued: ["0xFAF0cEe6B20e2Aaa4B80748a6AF4CD89609a3d78"],
     },
+    tron: {
+        issued: ["TF39FD5YwW63mtB1zr9gpVdyFUx1icac2y"]
+    }
   };
   
   import { addChainExports } from "../helper/getSupply";


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.


---
(fill in below form only for new listings)

##### Name (to be shown on DefiLlama): Palm USD


##### Website Link: https://www.palmusd.com/


##### Logo (High resolution, will be shown with rounded borders): 
![palm](https://github.com/user-attachments/assets/307ab718-1b51-454a-a336-fb630c577c70)



##### Chain: Ethereum, Binance Smart Chain, Tron


##### Coingecko ID (leave empty if not listed): 


##### Coinmarketcap ID (leave empty if not listed): 


##### Short Description: Palm tokens maintain a 1:1 peg with real-world currencies and are fully backed by cash and Shariah-compliant financial products. This structure provides traders, merchants, and funds with a secure, low-volatility means to exit market positions while adhering to sound finance principles

##### mintRedeemDescription: Palm customers and other institutions who have undergone a verification process can exchange currency for PUSD and redeem PUSD for currency


##### Token address and ticker: Eth: 0xfaf0cee6b20e2aaa4b80748a6af4cd89609a3d78,
BSC: 0xFAF0cEe6B20e2Aaa4B80748a6AF4CD89609a3d78,
Tron: TF39FD5YwW63mtB1zr9gpVdyFUx1icac2y


##### pegType: Fiat

##### pegMechanism: fiat-backed

##### priceSource:

##### wiki:

##### Twitter Link: https://x.com/joinpalmfi


##### List of audit links if any: