### PR TITLE
Add StraitsX XSGD support on Ethereum, Polygon, Avalanche, and Arbitrum

### DIFF
--- a/src/adapters/peggedAssets/straitsx-xsgd/index.ts
+++ b/src/adapters/peggedAssets/straitsx-xsgd/index.ts
@@ -1,0 +1,20 @@
+const pegType = "peggedSGD";
+
+const chainContracts =  {
+    ethereum: {
+      issued: ["0x70e8de73ce538da2beed35d14187f6959a8eca96"], pegType,
+    },
+    polygon: {
+        issued: ["0xdc3326e71d45186f113a2f448984ca0e8d201995"], pegType,
+      },
+    avax: {
+        issued: ["0xb2f85b7ab3c2b6f62df06de6ae7d09c010a5096e"], pegType,
+      },
+    arbitrum: {
+        issued: ["0xE333e7754a2DC1E020a162Ecab019254b9DaB653"], pegType,
+      },
+  }
+  
+  import { addChainExports } from "../helper/getSupply";
+  const adapter = addChainExports(chainContracts);
+  export default adapter;


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.


---
(fill in below form only for new listings)

##### Name (to be shown on DefiLlama): StraitsX XSGD


##### Website Link: https://www.straitsx.com/xsgd


##### Logo (High resolution, will be shown with rounded borders): https://logo.svgcdn.com/token-branded/xsgd.png


##### Chain: Ethereum, Polygon, Avalanche, Arbitrum


##### Coingecko ID (leave empty if not listed): xsgd


##### Coinmarketcap ID (leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description: XSGD is a Singapore Dollar-backed stablecoin issued by StraitsX. Every XSGD token is backed 1:1 with SGD and supported across multiple blockchain networks

##### mintRedeemDescription: Users may mint and redeem XSGD through verified StraitsX accounts via bank transfer or supported payment rails.


##### Token address and ticker:
Ethereum:
https://etherscan.io/token/0x70e8de73ce538da2beed35d14187f6959a8eca96
XSGD

Polygon:
https://polygonscan.com/token/0xdc3326e71d45186f113a2f448984ca0e8d201995
XSGD

Avalanche (C-Chain):
https://snowtrace.io/token/0xb2f85b7ab3c2b6f62df06de6ae7d09c010a5096e
XSGD

Arbitrum:
https://arbiscan.io/token/0xE333e7754a2DC1E020a162Ecab019254b9DaB653
XSGD

##### pegType: peggedSGD

##### pegMechanism: fiat-backed

##### priceSource: defillama

##### wiki: https://www.straitsx.com/xsgd

##### Twitter Link: https://twitter.com/straitsx


##### List of audit links if any: