### PR TITLE
Add KEI stablecoin support on Hyperliquid

### DIFF
--- a/src/adapters/peggedAssets/kei-stablecoin/index.ts
+++ b/src/adapters/peggedAssets/kei-stablecoin/index.ts
@@ -1,0 +1,9 @@
+const chainContracts = {
+    hyperliquid: {
+      issued: ["0xb5fe77d323d69eb352a02006ea8ecc38d882620c"],
+    },
+  };
+  
+  import { addChainExports } from "../helper/getSupply";
+  const adapter = addChainExports(chainContracts);
+  export default adapter;


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.


---
(fill in below form only for new listings)

##### Name (to be shown on DefiLlama):  KEI Stablecoin


##### Website Link: https://keikofinance.com


##### Logo (High resolution, will be shown with rounded borders): https://coin-images.coingecko.com/coins/images/55084/large/kei.jpg?1743648809


##### Chain: Hyperliquid / HyperEVM


##### Coingecko ID (leave empty if not listed):  kei-stablecoin


##### Coinmarketcap ID (leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description: KEI is a USD-pegged stablecoin issued by Keiko Finance. Users can mint KEI by depositing supported crypto collateral into the Keiko Protocol. It maintains a 1:1 peg to USD through over-collateralization and vault mechanics

##### mintRedeemDescription: Users may mint and redeem KEI through the Keiko Protocol by depositing and withdrawing supported crypto collateral via on-chain vaults.


##### Token address and ticker:

Hyperliquid / HyperEVM:
https://hyperevmscan.io/token/0xb5fe77d323d69eb352a02006ea8ecc38d882620c
KEI


##### pegType: peggedUSD

##### pegMechanism: crypto-backed

##### priceSource: defillama

##### wiki: https://docs.keikofinance.com/protocol-overview/kei-stablecoin

##### Twitter Link: https://twitter.com/KeikoFinance

##### List of audit links if any: