### PR TITLE
Add Last USD USDXL adapter

### DIFF
--- a/src/adapters/peggedAssets/last-usd/index.ts
+++ b/src/adapters/peggedAssets/last-usd/index.ts
@@ -1,0 +1,9 @@
+const chainContracts = {
+    hyperliquid: {
+      issued: ["0xca79db4b49f608ef54a5cb813fbed3a6387bc645"],
+    },
+  };
+  
+  import { addChainExports } from "../helper/getSupply";
+  const adapter = addChainExports(chainContracts);
+  export default adapter;


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.


---
(fill in below form only for new listings)

##### Name (to be shown on DefiLlama):  Last USD (USDXL)


##### Website Link: https://www.last.net/


##### Logo (High resolution, will be shown with rounded borders): https://coin-images.coingecko.com/coins/images/55083/large/usdxl.jpg?1743648438


##### Chain: Hyperliquid


##### Coingecko ID (leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list) last-usd


##### Coinmarketcap ID (leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description: Last USD (USDXL) is a crypto-backed stablecoin designed to maintain a peg to the U.S. dollar.

##### mintRedeemDescription: USDXL lets users mint synthetic dollars against blue chip over-collateralized cryptoassets


##### Token address and ticker:
https://hyperevmscan.io/token/0xca79db4b49f608ef54a5cb813fbed3a6387bc645

##### pegType: peggedUSD

##### pegMechanism: crypto-backed

##### priceSource: defillama

##### wiki: 

##### Twitter Link: https://x.com/lastdotnet


##### List of audit links if any: