### PR TITLE
Add hyperliquid native stablecoin USDH

### DIFF
--- a/src/adapters/peggedAssets/hyperliquid-native-stablecoin/index.ts
+++ b/src/adapters/peggedAssets/hyperliquid-native-stablecoin/index.ts
@@ -1,0 +1,9 @@
+const chainContracts = {
+    hyperliquid: {
+      issued: ["0x111111a1a0667d36bd57c0a9f569b98057111111"],
+    },
+  };
+  
+  import { addChainExports } from "../helper/getSupply";
+  const adapter = addChainExports(chainContracts);
+  export default adapter;


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.


---
(fill in below form only for new listings)

##### Name (to be shown on DefiLlama):  USDH Stablecoin


##### Website Link: https://nativemarkets.com/


##### Logo (High resolution, will be shown with rounded borders):  https://coin-images.coingecko.com/coins/images/69484/large/usdh.png?1758728903


##### Chain: Hyperliquid


##### Coingecko ID (leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list) usdh-2


##### Coinmarketcap ID (leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description: USDH is a fiat-backed digital dollar built natively for Hyperliquid. Designed by Native Markets and issued by Bridge Building Inc, it delivers a credible, ecosystem-aligned, and native dollar solution for Hyperliquid.

##### mintRedeemDescription: USDH is fully reserved by cash, short-term U.S. Treasuries, repo agreements, treasury-focused funds (e.g., BlackRock TTTXX), and tokenized treasury products (e.g., BlackRock BUIDL, Superstate USTB).

Cash is custodied at U.S.-regulated banks

TradFi assets are custodied at JP Morgan

Crypto assets are custodied in Bridge’s Fireblocks-powered MPC system

BPM (a top-40 U.S. accounting firm) provides monthly attestations confirming 1:1 backing

Native Markets programmatically contributes 50% of USDH gross revenue to the Hyperliquid Assistance Fund (AF) under the AQA protocol, enabling the protocol to buy back HYPE.


##### Token address and ticker: 0x111111a1a0667d36bd57c0a9f569b98057111111
https://hyperevmscan.io/token/0x111111a1a0667d36bd57c0a9f569b98057111111


##### pegType: peggedUSD

##### pegMechanism: fiat-backed

##### priceSource: defillama

##### wiki:

##### Twitter Link: https://x.com/nativemarkets


##### List of audit links if any: