### PR TITLE
Add Mento British Pound

### DIFF
--- a/src/adapters/peggedAssets/mento-british-pound/index.ts
+++ b/src/adapters/peggedAssets/mento-british-pound/index.ts
@@ -1,0 +1,13 @@
+import type { ChainContracts } from "../peggedAsset.type";
+
+const chainContracts: ChainContracts = {
+  celo: {
+    issued: ["0xCCF663b1fF11028f0b19058d0f7B674004a40746"],
+  },
+  monad: {
+    bridgedFromCelo: ["0x39bb4E0a204412bB98e821d25e7d955e69d40Fd1"], // portal
+  },
+};
+
+import { addChainExports } from "../helper/getSupply";
+export default addChainExports(chainContracts);

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -7293,5 +7293,24 @@ export default [
     wiki: "https://blog.soniclabs.com/ussd-sonics-native-permissionless-usd-stablecoin-built-with-frax/",
     module: "us-sonic-dollar",
     doublecounted: true
-  }
+  },
+  {
+    id: "357",
+    name: "Mento British Pound",
+    address: "celo:0xCCF663b1fF11028f0b19058d0f7B674004a40746",
+    symbol: "GBPm",
+    url: "https://www.mento.org/",
+    description:
+      "GBPm is a GBP-pegged synthetic stablecoin on Celo, part of the Mento Protocol. It is minted via Liquity v2-style CDPs: users deposit USDm as collateral and borrow GBPm against it.",
+    mintRedeemDescription:
+      "GBPm is minted by depositing USDm as collateral into a Mento CDP (trove) and borrowing GBPm against it. Repaying the borrowed GBPm closes or reduces the trove and releases the USDm collateral.",
+    onCoinGecko: "true",
+    gecko_id: "mento-british-pound",
+    cmcId: null,
+    pegType: "peggedGBP",
+    pegMechanism: "crypto-backed",
+    priceSource: "defillama",
+    auditLinks: ["https://docs.mento.org/mento-v3/dive-deeper/security/audit-reports"],
+    twitter: "https://twitter.com/MentoLabs",
+  },
 ] as PeggedAsset[];


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.


---
(fill in below form only for new listings)

##### Name (to be shown on DefiLlama): Mento British Pound


##### Website Link: https://www.mento.org/


##### Logo (High resolution, will be shown with rounded borders):
![](https://raw.githubusercontent.com/monad-crypto/token-list/22781882dc845b71b6aaecd3f5120f85fe18d3ac/mainnet/GBPm/logo.svg)

##### Chain: Celo


##### Coingecko ID (leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)
mento-british-pound

##### Coinmarketcap ID (leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description:
GBPm is a GBP-pegged synthetic stablecoin on Celo, part of the Mento Protocol. It is minted via Liquity v2-style CDPs: users deposit USDm as collateral and borrow GBPm against it.

##### mintRedeemDescription:
GBPm is minted by depositing USDm as collateral into a Mento CDP (trove) and borrowing GBPm against it. Repaying the borrowed GBPm closes or reduces the trove and releases the USDm collateral.

##### Token address and ticker:
0xCCF663b1fF11028f0b19058d0f7B674004a40746, GBPm

##### pegType: peggedGBP

##### pegMechanism: crypto-backed

##### priceSource: defillama

##### wiki:

##### Twitter Link: https://twitter.com/MentoLabs


##### List of audit links if any: https://docs.mento.org/mento-v3/dive-deeper/security/audit-reports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added support for Mento British Pound (GBPm), a GBP-pegged synthetic stablecoin on Celo. GBPm operates through the Mento Protocol, allowing users to mint the asset by depositing collateral through Liquity-style CDPs and borrowing against it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->