### PR TITLE
Add Alto DUSD to the pegged assets server

### DIFF
--- a/src/adapters/peggedAssets/alto-dusd/index.ts
+++ b/src/adapters/peggedAssets/alto-dusd/index.ts
@@ -1,0 +1,10 @@
+const chainContracts = {
+  ethereum: {
+    issued: ["0x63d74d22E689C715a04F2C13962b1f77F443d35b"],
+  },
+};
+
+import { addChainExports } from "../helper/getSupply";
+
+const adapter = addChainExports(chainContracts);
+export default adapter;

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -7296,22 +7296,22 @@ export default [
   },
   {
     id: "357",
-    name: "DUSD",
+    name: "Alto DUSD",
     address: "0x63d74d22E689C715a04F2C13962b1f77F443d35b",
     symbol: "DUSD",
-    url: "https://alto.money/",
+    url: "https://altofoundation.org/",
     description:
-      "DUSD is Alto’s native stablecoin and the unit of account inside all markets.",
+      "DUSD is a crypto-backed stablecoin pegged to the US Dollar, issued through the Alto lending protocol. It is minted against collateral assets deposited into Alto markets and can be redeemed 1:1 for USDC via the Permissionless PSM, subject to available USDC liquidity.",
     mintRedeemDescription:
-      "DUSD is minted through permissioned and permissionless peg stability modules.",
+      "Users mint DUSD by depositing collateral into Alto mint markets. DUSD is burned when the loan is repaid. DUSD can also be exchanged 1:1 for USDC through the Permissionless PSM, subject to available USDC liquidity in the PSM.",
     onCoinGecko: "true",
     gecko_id: "alto-dusd",
     cmcId: null,
     pegType: "peggedUSD",
     pegMechanism: "crypto-backed",
-    auditLinks: null,
-    priceSource: "defillama",
+    auditLinks: ["https://github.com/altomoney/Security-Review-Engagements"],
+    priceSource: "coingecko",
     twitter: "https://x.com/alto_money",
     wiki: "https://docs.alto.money/",
-  }
+}
 ] as PeggedAsset[];

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -7293,5 +7293,25 @@ export default [
     wiki: "https://blog.soniclabs.com/ussd-sonics-native-permissionless-usd-stablecoin-built-with-frax/",
     module: "us-sonic-dollar",
     doublecounted: true
+  },
+  {
+    id: "357",
+    name: "DUSD",
+    address: "0x63d74d22E689C715a04F2C13962b1f77F443d35b",
+    symbol: "DUSD",
+    url: "https://alto.money/",
+    description:
+      "DUSD is Alto’s native stablecoin and the unit of account inside all markets.",
+    mintRedeemDescription:
+      "DUSD is minted through permissioned and permissionless peg stability modules.",
+    onCoinGecko: "true",
+    gecko_id: "alto-dusd",
+    cmcId: null,
+    pegType: "peggedUSD",
+    pegMechanism: "crypto-backed",
+    auditLinks: null,
+    priceSource: "defillama",
+    twitter: "https://x.com/alto_money",
+    wiki: "https://docs.alto.money/",
   }
 ] as PeggedAsset[];


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
Alto

##### Website Link:
https://www.altofoundation.org/

##### Logo (High resolution, will be shown with rounded borders):
https://ogqctdyovgvwilkqwdxv.supabase.co/storage/v1/object/public/assets/media/defillama/alto_logo.png

##### Chain:
Ethereum

##### Coingecko ID (leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)
`alto-dusd`

##### Coinmarketcap ID (leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
\-

##### Short Description:
DUSD is a crypto-backed stablecoin pegged to the US Dollar, issued through the Alto lending protocol. It is minted against collateral assets deposited into Alto markets and can be redeemed 1:1 for USDC via the Permissionless PSM, subject to available USDC liquidity.

##### mintRedeemDescription:
Users mint DUSD by depositing collateral into Alto mint markets. DUSD is burned when the loan is repaid. DUSD can also be exchanged 1:1 for USDC through the Permissionless PSM, subject to available USDC liquidity in the PSM.

##### Token address and ticker:
`0x63d74d22E689C715a04F2C13962b1f77F443d35b`
`DUSD`

##### pegType:
`peggedUSD`

##### pegMechanism:
`crypto-backed`

##### priceSource:
`defillama`

##### wiki:
https://docs.alto.money/

##### Twitter Link:
https://x.com/alto_money


##### List of audit links if any:
https://github.com/altomoney/Security-Review-Engagements

**We can't enable enable "Allow edits by maintainers" as this is an org repository. Let us know who to add to this repository if edits are required.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Alto DUSD pegged asset is now available on the platform with full asset registry support and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->