### PR TITLE
USDX depeg

### DIFF
--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -4503,6 +4503,7 @@ export default [
     twitter: "https://x.com/usdx_money",
     wiki: "https://docs.usdx.money/a-synthetic-usd/usdx-basics",
     deadUrl: true,
+    deadFrom: "2025-11-14",
   },
   {
     id: "215",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated USDX Money USDX pegged asset as inactive effective November 14, 2025.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->