### PR TITLE
feat(wad): add Voi Network chain to WAD stablecoin adapter

### DIFF
--- a/src/adapters/peggedAssets/wad-stablecoin/index.ts
+++ b/src/adapters/peggedAssets/wad-stablecoin/index.ts
@@ -14,7 +14,7 @@
  *
  * Voi Network:
  *   WAD is an ARC-200 token minted exclusively via collateralized borrowing
- *   through DorkFi's A-Market. There is no pre-minted reserve — every WAD
+ *   through DorkFi's A-Market. There is no pre-minted reserve - every WAD
  *   in existence is circulating. Circulating supply = arc200_totalSupply.
  *   The totalSupply is stored as a big-endian byte value in the app's
  *   global state under the key "totalSupply".
@@ -31,18 +31,14 @@ import { lookupAccountByID } from "../helper/algorand";
 const axios = require("axios");
 const retry = require("async-retry");
 
-// ── Algorand ─────────────────────────────────────────────────────────────────
-
 const WAD_ASSET_ID = 3334160924;
 const WAD_DECIMALS = 6;
-// Creator wallet — holds all un-minted WAD supply on Algorand
+// Creator wallet - holds all un-minted WAD supply on Algorand
 const WAD_CREATOR = "KTKMGUA2YWZ4OF4P2UBDE57CYS2YRF6S7275EAF6VVC5D2Z3T6YNMBIMQM";
 const ALGONODE_INDEXER = "https://mainnet-idx.algonode.cloud";
 
-// ── Voi Network ───────────────────────────────────────────────────────────────
-
 const WAD_VOI_APP_ID = 47138068;
-const VOI_INDEXER    = "https://mainnet-idx.voi.nodely.dev";
+const VOI_INDEXER = "https://mainnet-idx.voi.nodely.dev";
 
 /**
  * minted (Algorand) = total ASA supply (uint64 max).
@@ -54,7 +50,9 @@ async function algorandMinted() {
 
     const assetRes = await retry(
       async (_bail: any) =>
-        await axios.get(`${ALGONODE_INDEXER}/v2/assets/${WAD_ASSET_ID}`, { timeout: 30000 })
+        await axios.get(`${ALGONODE_INDEXER}/v2/assets/${WAD_ASSET_ID}`, {
+          timeout: 30000,
+        })
     );
 
     const totalRaw: string = String(
@@ -82,6 +80,7 @@ async function algorandUnreleased() {
       )?.amount ?? 0;
 
     const creatorWAD = creatorBalanceRaw / 10 ** WAD_DECIMALS;
+
     sumSingleBalance(balances, "peggedUSD", creatorWAD);
     return balances;
   };
@@ -92,7 +91,7 @@ async function algorandUnreleased() {
  *
  * The ARC-200 contract stores totalSupply as big-endian bytes under the
  * key "totalSupply" in global state. WAD on Voi is minted on-demand via
- * collateralized borrowing — there is no pre-minted reserve, so the
+ * collateralized borrowing - there is no pre-minted reserve, so the
  * entire totalSupply equals circulating supply.
  */
 async function voiMinted() {
@@ -101,23 +100,46 @@ async function voiMinted() {
 
     const appRes = await retry(
       async (_bail: any) =>
-        await axios.get(`${VOI_INDEXER}/v2/applications/${WAD_VOI_APP_ID}`, { timeout: 30000 })
+        await axios.get(`${VOI_INDEXER}/v2/applications/${WAD_VOI_APP_ID}`, {
+          timeout: 30000,
+        })
     );
 
     const globalState: any[] =
       appRes?.data?.application?.params?.["global-state"] ?? [];
 
-    // Find "totalSupply" key (base64-encoded)
+    // Find "totalSupply" key (base64-encoded).
     const TOTAL_SUPPLY_KEY = Buffer.from("totalSupply").toString("base64");
     const entry = globalState.find((x: any) => x.key === TOTAL_SUPPLY_KEY);
+    const appId = appRes?.data?.application?.id ?? WAD_VOI_APP_ID;
 
-    let totalWAD = 0;
-    if (entry?.value?.bytes) {
-      const raw = Buffer.from(entry.value.bytes, "base64");
-      const totalRaw = BigInt("0x" + raw.toString("hex"));
-      totalWAD = Number(totalRaw) / 10 ** WAD_DECIMALS;
+    if (!entry || typeof entry.value?.bytes !== "string") {
+      throw new Error(
+        `Missing totalSupply global-state bytes for Voi WAD app ${appId} (key ${TOTAL_SUPPLY_KEY})`
+      );
     }
 
+    let totalRaw: bigint;
+    try {
+      const encodedBytes = entry.value.bytes;
+      const raw = Buffer.from(encodedBytes, "base64");
+      const normalizedInput = encodedBytes.replace(/=+$/, "");
+      const normalizedDecoded = raw.toString("base64").replace(/=+$/, "");
+      if (normalizedInput !== normalizedDecoded) {
+        throw new Error("invalid base64");
+      }
+
+      const rawHex = raw.toString("hex");
+      totalRaw = BigInt(`0x${rawHex || "0"}`);
+    } catch (error) {
+      throw new Error(
+        `Failed to decode totalSupply global-state bytes for Voi WAD app ${appId} (key ${TOTAL_SUPPLY_KEY}): ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+
+    const totalWAD = Number(totalRaw) / 10 ** WAD_DECIMALS;
     sumSingleBalance(balances, "peggedUSD", totalWAD, "issued", false);
     return balances;
   };
@@ -125,12 +147,12 @@ async function voiMinted() {
 
 const adapter: PeggedIssuanceAdapter = {
   algorand: {
-    minted:     algorandMinted(),
+    minted: algorandMinted(),
     unreleased: algorandUnreleased(),
   },
   voi: {
     minted: voiMinted(),
-    // No unreleased — WAD on Voi is only minted via borrowing, never pre-minted
+    // No unreleased - WAD on Voi is only minted via borrowing, never pre-minted.
   },
 };
 

--- a/src/adapters/peggedAssets/wad-stablecoin/index.ts
+++ b/src/adapters/peggedAssets/wad-stablecoin/index.ts
@@ -6,17 +6,18 @@
  *
  * Chains:
  *   - Algorand: ASA ID 3334160924 (6 decimals)
+ *   - Voi Network: ARC-200 app ID 47138068 (6 decimals)
  *
- * The ASA `total` is set to uint64 max (effectively uncapped).
- * Circulating supply = total_issued - creator_reserve_balance.
+ * Algorand:
+ *   The ASA `total` is set to uint64 max (effectively uncapped).
+ *   Circulating = total_issued - creator_reserve_balance.
  *
- * We compute this as:
- *   minted    = total_supply (uint64 max, in WAD) — NOTE: BigInt required for precision
- *   unreleased = creator_wallet_balance
- *   circulating (computed by framework) = minted - unreleased
- *
- * Creator / reserve address (holds all un-minted WAD):
- *   KTKMGUA2YWZ4OF4P2UBDE57CYS2YRF6S7275EAF6VVC5D2Z3T6YNMBIMQM
+ * Voi Network:
+ *   WAD is an ARC-200 token minted exclusively via collateralized borrowing
+ *   through DorkFi's A-Market. There is no pre-minted reserve — every WAD
+ *   in existence is circulating. Circulating supply = arc200_totalSupply.
+ *   The totalSupply is stored as a big-endian byte value in the app's
+ *   global state under the key "totalSupply".
  */
 
 import {
@@ -30,16 +31,22 @@ import { lookupAccountByID } from "../helper/algorand";
 const axios = require("axios");
 const retry = require("async-retry");
 
+// ── Algorand ─────────────────────────────────────────────────────────────────
+
 const WAD_ASSET_ID = 3334160924;
 const WAD_DECIMALS = 6;
-// Creator wallet — holds all un-minted WAD supply
+// Creator wallet — holds all un-minted WAD supply on Algorand
 const WAD_CREATOR = "KTKMGUA2YWZ4OF4P2UBDE57CYS2YRF6S7275EAF6VVC5D2Z3T6YNMBIMQM";
 const ALGONODE_INDEXER = "https://mainnet-idx.algonode.cloud";
 
+// ── Voi Network ───────────────────────────────────────────────────────────────
+
+const WAD_VOI_APP_ID = 47138068;
+const VOI_INDEXER    = "https://mainnet-idx.voi.nodely.dev";
+
 /**
- * minted = total ASA supply (uint64 max).
- * We use BigInt to avoid float precision loss at large values, then
- * convert to a regular number once divided by decimals.
+ * minted (Algorand) = total ASA supply (uint64 max).
+ * BigInt used to avoid float precision loss.
  */
 async function algorandMinted() {
   return async function (_ts: any, _block: any, _chainBlocks: ChainBlocks) {
@@ -47,10 +54,9 @@ async function algorandMinted() {
 
     const assetRes = await retry(
       async (_bail: any) =>
-        await axios.get(`${ALGONODE_INDEXER}/v2/assets/${WAD_ASSET_ID}`)
+        await axios.get(`${ALGONODE_INDEXER}/v2/assets/${WAD_ASSET_ID}`, { timeout: 30000 })
     );
 
-    // Use string to preserve precision, then BigInt
     const totalRaw: string = String(
       assetRes?.data?.asset?.params?.total ?? "0"
     );
@@ -62,8 +68,8 @@ async function algorandMinted() {
 }
 
 /**
- * unreleased = creator wallet balance (un-minted WAD sitting in reserve).
- * circulating (computed by framework) = minted - unreleased ≈ 10,600 WAD
+ * unreleased (Algorand) = creator wallet balance (un-minted WAD in reserve).
+ * circulating = minted - unreleased
  */
 async function algorandUnreleased() {
   return async function (_ts: any, _block: any, _chainBlocks: ChainBlocks) {
@@ -76,16 +82,55 @@ async function algorandUnreleased() {
       )?.amount ?? 0;
 
     const creatorWAD = creatorBalanceRaw / 10 ** WAD_DECIMALS;
-
     sumSingleBalance(balances, "peggedUSD", creatorWAD);
+    return balances;
+  };
+}
+
+/**
+ * minted (Voi) = ARC-200 totalSupply from app global state.
+ *
+ * The ARC-200 contract stores totalSupply as big-endian bytes under the
+ * key "totalSupply" in global state. WAD on Voi is minted on-demand via
+ * collateralized borrowing — there is no pre-minted reserve, so the
+ * entire totalSupply equals circulating supply.
+ */
+async function voiMinted() {
+  return async function (_ts: any, _block: any, _chainBlocks: ChainBlocks) {
+    const balances = {} as Balances;
+
+    const appRes = await retry(
+      async (_bail: any) =>
+        await axios.get(`${VOI_INDEXER}/v2/applications/${WAD_VOI_APP_ID}`, { timeout: 30000 })
+    );
+
+    const globalState: any[] =
+      appRes?.data?.application?.params?.["global-state"] ?? [];
+
+    // Find "totalSupply" key (base64-encoded)
+    const TOTAL_SUPPLY_KEY = Buffer.from("totalSupply").toString("base64");
+    const entry = globalState.find((x: any) => x.key === TOTAL_SUPPLY_KEY);
+
+    let totalWAD = 0;
+    if (entry?.value?.bytes) {
+      const raw = Buffer.from(entry.value.bytes, "base64");
+      const totalRaw = BigInt("0x" + raw.toString("hex"));
+      totalWAD = Number(totalRaw) / 10 ** WAD_DECIMALS;
+    }
+
+    sumSingleBalance(balances, "peggedUSD", totalWAD, "issued", false);
     return balances;
   };
 }
 
 const adapter: PeggedIssuanceAdapter = {
   algorand: {
-    minted: algorandMinted(),
+    minted:     algorandMinted(),
     unreleased: algorandUnreleased(),
+  },
+  voi: {
+    minted: voiMinted(),
+    // No unreleased — WAD on Voi is only minted via borrowing, never pre-minted
   },
 };
 

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -7454,7 +7454,7 @@ export default [
   {
     id: "364",
     name: "Whale Asset Dollar",
-    address: "algorand:3334160924,voi:47138068",
+    address: "algorand:3334160924",
     symbol: "WAD",
     url: "https://dork.fi",
     description: "WAD is an overcollateralized stablecoin minted through DorkFi, a cross-chain borrow/lend protocol on the Algorand Virtual Machine (AVM). Users deposit collateral assets and borrow WAD at controlled interest rates.",

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -7454,7 +7454,7 @@ export default [
   {
     id: "364",
     name: "Whale Asset Dollar",
-    address: "algorand:3334160924",
+    address: "algorand:3334160924,voi:47138068",
     symbol: "WAD",
     url: "https://dork.fi",
     description: "WAD is an overcollateralized stablecoin minted through DorkFi, a cross-chain borrow/lend protocol on the Algorand Virtual Machine (AVM). Users deposit collateral assets and borrow WAD at controlled interest rates.",


### PR DESCRIPTION
## WAD on Voi Network

WAD (Whale Asset Dollar) is live on two chains. The original PR #736 only covered Algorand. This adds Voi Network.

### Voi Details
- **Token type**: ARC-200 (app ID 47138068, 6 decimals)
- **Circulating supply**: ~21,559 WAD (live, queried from on-chain global state)
- **Minting mechanism**: Minted exclusively via collateralized borrowing through DorkFi's A-Market — no pre-minted reserve exists, so `totalSupply = circulating supply`
- **Supply source**: `totalSupply` key in ARC-200 app global state (big-endian bytes), via Voi Network indexer (`mainnet-idx.voi.nodely.dev`)

### Changes
- `wad-stablecoin/index.ts`: Added `voiMinted()` function; exported `voi` chain in adapter
- `peggedData.ts`: Added `voi:47138068` to WAD address field

### Links
- Protocol: https://dork.fi
- Voi explorer: https://block.voi.network/explorer/application/47138068
- Original PR: #736

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WAD stablecoin now supported on Voi Network in addition to Algorand.
  * Whale Asset Dollar issuance tracking updated to include Voi addresses.

* **Bug Fixes / Improvements**
  * Supply reporting refined for Voi (treats platform total supply as circulating).
  * Improved reliability of Algorand asset queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->