### PR TITLE
Add phUSD pegged asset adapter

### DIFF
--- a/src/adapters/peggedAssets/phusd/index.ts
+++ b/src/adapters/peggedAssets/phusd/index.ts
@@ -1,0 +1,9 @@
+const chainContracts = {
+  ethereum: {
+    issued: ["0xf3B5B661b92B75C71fA5Aba8Fd95D7514A9CD605"],
+  },
+};
+
+import { addChainExports } from "../helper/getSupply";
+const adapter = addChainExports(chainContracts);
+export default adapter;

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -7667,7 +7667,7 @@ export default [
     mintRedeemDescription:
       "phUSD is minted 1:1 by depositing supported stablecoins (DOLA, USDC) through PhusdStableMinter. The underlying stablecoins are routed into ERC4626 yield strategies (AutoDOLA, AutoUSDC). phUSD can be redeemed 1:1 for the underlying stablecoins at any time.",
     onCoinGecko: "false",
-    gecko_id: null,
+    gecko_id: "phusd",
     cmcId: null,
     pegType: "peggedUSD",
     pegMechanism: "crypto-backed",
@@ -7676,5 +7676,6 @@ export default [
     twitter: null,
     wiki: null,
     module: "phusd",
+    doublecounted: true
   },
 ] as PeggedAsset[];

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -7656,4 +7656,25 @@ export default [
     twitter: "https://x.com/SuiNetwork",
     module: "usdsui",
   },
+  {
+    id: "374",
+    name: "Phoenix USD",
+    address: "0xf3B5B661b92B75C71fA5Aba8Fd95D7514A9CD605",
+    symbol: "phUSD",
+    url: "https://phusd.behodler.io",
+    description:
+      "phUSD is a USD stablecoin on Ethereum backed 1:1 by a basket of yield-bearing stablecoin collateral (DOLA and USDC) held in ERC4626 yield strategies. Deposits earn yield which is streamed to phUSD stakers via the Phlimbo yield farm.",
+    mintRedeemDescription:
+      "phUSD is minted 1:1 by depositing supported stablecoins (DOLA, USDC) through PhusdStableMinter. The underlying stablecoins are routed into ERC4626 yield strategies (AutoDOLA, AutoUSDC). phUSD can be redeemed 1:1 for the underlying stablecoins at any time.",
+    onCoinGecko: "false",
+    gecko_id: null,
+    cmcId: null,
+    pegType: "peggedUSD",
+    pegMechanism: "crypto-backed",
+    priceSource: "defillama",
+    auditLinks: null,
+    twitter: null,
+    wiki: null,
+    module: "phusd",
+  },
 ] as PeggedAsset[];


### PR DESCRIPTION
Adds phUSD (Phoenix USD, `0xf3B5B661b92B75C71fA5Aba8Fd95D7514A9CD605`) as a new pegged asset on Ethereum mainnet.

- Minimal 9-line adapter following the `apxusd` template (reports `erc20:totalSupply` via `addChainExports`)
- New entry in `src/peggedData/peggedData.ts` with id `374`, `pegType: peggedUSD`, `pegMechanism: crypto-backed`
- Not on CoinGecko (`onCoinGecko: "false"`, `gecko_id: null`, `module: "phusd"`)

phUSD is minted 1:1 against DOLA/USDC deposits via `PhusdStableMinter`; deposits are routed into ERC4626 yield strategies (AutoDOLA, AutoUSDC). Website: https://phusd.behodler.io

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Phoenix USD (phUSD) as a supported pegged asset (crypto-backed USD peg) with Ethereum contract tracking.
  * Integrated on-chain supply reporting for phUSD and wired DefiLlama as the price source.
  * phUSD is marked as double-counted in aggregated views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->