### PR TITLE
fix: correct phUSD mintRedeemDescription — phUSD is not redeemable

### DIFF
--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -7665,7 +7665,7 @@ export default [
     description:
       "phUSD is a USD stablecoin on Ethereum backed 1:1 by a basket of yield-bearing stablecoin collateral (DOLA and USDC) held in ERC4626 yield strategies. Deposits earn yield which is streamed to phUSD stakers via the Phlimbo yield farm.",
     mintRedeemDescription:
-      "phUSD is minted 1:1 by depositing supported stablecoins (DOLA, USDC) through PhusdStableMinter. The underlying stablecoins are routed into ERC4626 yield strategies (AutoDOLA, AutoUSDC). phUSD can be redeemed 1:1 for the underlying stablecoins at any time.",
+      "phUSD is minted 1:1 by depositing supported stablecoins (DOLA, USDC) through PhusdStableMinter. The underlying stablecoins are routed into ERC4626 yield strategies (AutoDOLA, AutoUSDC). phUSD is not redeemable.",
     onCoinGecko: "false",
     gecko_id: "phusd",
     cmcId: null,


### PR DESCRIPTION
## Summary
- Correct the phUSD `mintRedeemDescription` to remove the incorrect claim that phUSD is redeemable 1:1 for its underlying stablecoins.
- phUSD can be minted by depositing DOLA or USDC through `PhusdStableMinter`, but it is **not redeemable**. The previous wording misrepresented this on the DefiLlama page.

The rest of the entry (description, backing, yield-streaming via Phlimbo) is unchanged and accurate.

## Test plan
- [x] `mintRedeemDescription` string updated in `src/peggedData/peggedData.ts`
- [x] No other fields touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated phUSD asset information to clarify that it is not redeemable, correcting previous redemption terms details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->