### PR TITLE
Feat: add monet-usdmo adapter

### DIFF
--- a/src/adapters/peggedAssets/monet-usdmo/index.ts
+++ b/src/adapters/peggedAssets/monet-usdmo/index.ts
@@ -1,0 +1,12 @@
+import { addChainExports } from "../helper/getSupply";
+import {ChainContracts,
+} from "../peggedAsset.type";
+
+const chainContracts:ChainContracts = {
+    eden:{
+        issued: ["0x9fa8c4d9f33dcce6eacefb6d5cf9736350a330b1"],
+    },
+};
+  
+const adapter = addChainExports(chainContracts);
+export default adapter;


### PR DESCRIPTION
Link to Monet PR: https://github.com/DefiLlama/DefiLlama-Adapters/pull/18872

USDmo: [0x9fa8c4d9f33dcce6eacefb6d5cf9736350a330b1](https://eden.blockscout.com/address/0x9fa8c4d9f33dcce6eacefb6d5cf9736350a330b1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for USDMO pegged asset adapter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->