### PR TITLE
feat: add fxUSD config for Base

### DIFF
--- a/src/adapters/peggedAssets/fxusd/layerzeroConfig.ts
+++ b/src/adapters/peggedAssets/fxusd/layerzeroConfig.ts
@@ -1,0 +1,10 @@
+import type { LayerZeroConfig } from "../helper/bridgeConfig";
+
+const layerzeroConfig: LayerZeroConfig = {
+  sourceChain: "ethereum",
+  tokens: [
+    { chain: "base", address: "0x55380fe7a1910dff29a47b622057ab4139da42c5", decimals: 18 },
+  ],
+};
+
+export default layerzeroConfig;

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -3573,7 +3573,11 @@ export default [
     twitter: "https://twitter.com/protocol_fx",
     wiki: null,
     module: "fxusd",
-
+    bridgeConfig: {
+      lzConfig: {
+        symbols: ["fxUSD"],
+      },
+    },
   },
   {
     id: "169",


### PR DESCRIPTION
NOTE

add fxUSD config for Base

Please enable "Allow edits by maintainers" while putting up the PR.
(fill in below form only for new listings)

Name (to be shown on DefiLlama):
Website Link:
Logo (High resolution, will be shown with rounded borders):
Chain:
Coingecko ID (leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)
Coinmarketcap ID (leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
Short Description:
mintRedeemDescription:
Token address and ticker:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LayerZero cross-chain bridging support for fxUSD token
  * Configured Ethereum as the primary source network with Base network integration
  * Established standardized contract addresses and token precision across supported chains
  * Users can now securely bridge fxUSD between Ethereum and Base networks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->