### PR TITLE
DEX-530: Add USDso (USD Somnia) — native peggedUSD on Somnia

### DIFF
--- a/src/adapters/peggedAssets/usd-somnia/index.ts
+++ b/src/adapters/peggedAssets/usd-somnia/index.ts
@@ -1,0 +1,14 @@
+import { addChainExports } from "../helper/getSupply";
+import { ChainContracts, PeggedIssuanceAdapter } from "../peggedAsset.type";
+
+const chainContracts: ChainContracts = {
+  somnia: {
+    issued: ["0x00000022dA000002656c64D9eA6011ea952D008A"],
+  },
+};
+
+const adapter: PeggedIssuanceAdapter = addChainExports(chainContracts, undefined, {
+  decimals: 18,
+});
+
+export default adapter;

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -7781,4 +7781,25 @@ export default [
     wiki: "https://blog.sui.io/esui-dollar-suiusde-deepbook-margin/",
     module: "sui-usde",
   },
+  {
+    id: "377",
+    name: "USD Somnia",
+    address: "somnia:0x00000022da000002656c64d9ea6011ea952d008a",
+    symbol: "USDso",
+    url: "https://somnia.network/usdso-stablecoin",
+    description:
+      "USDso is a USD-pegged stablecoin available on the Somnia network. Minting and redemption are operated by Frax through its FraxNet branded-stablecoin program: USDso is collateralized 1:1 by frxUSD held in a Frax-operated BrandedCustodian vault on Somnia, with frxUSD's reserves consisting primarily of tokenized US Treasuries (BUIDL, USTB, USCC, WTGXX, JTRSY) and cash equivalents.",
+    mintRedeemDescription:
+      "Minting and redemption are handled by Frax on Somnia through the BrandedCustodian (an ERC-4626 vault): frxUSD is deposited 1:1 to receive USDso, and USDso can be burned via the same vault to receive the equivalent frxUSD. Cross-chain mint and redeem with USDC on supported chains is provided through Frax's orchestration API and CrossChainRouter.",
+    onCoinGecko: "false",
+    gecko_id: null,
+    cmcId: null,
+    pegType: "peggedUSD",
+    pegMechanism: "fiat-backed",
+    priceSource: "defillama",
+    auditLinks: null,
+    twitter: "https://x.com/Somnia_Network",
+    wiki: null,
+    module: "usd-somnia",
+  },
 ] as PeggedAsset[];

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -7792,7 +7792,7 @@ export default [
     mintRedeemDescription:
       "Minting and redemption are handled by Frax on Somnia through the BrandedCustodian (an ERC-4626 vault): frxUSD is deposited 1:1 to receive USDso, and USDso can be burned via the same vault to receive the equivalent frxUSD. Cross-chain mint and redeem with USDC on supported chains is provided through Frax's orchestration API and CrossChainRouter.",
     onCoinGecko: "false",
-    gecko_id: null,
+    gecko_id: "usd-somnia",
     cmcId: null,
     pegType: "peggedUSD",
     pegMechanism: "fiat-backed",


### PR DESCRIPTION
## Summary
- Adds USDso (USD Somnia), a USD-pegged stablecoin native to Somnia (chainId 5031). Token: [`0x00000022dA000002656c64D9eA6011ea952D008A`](https://explorer.somnia.network/token/0x00000022dA000002656c64D9eA6011ea952D008A), decimals 18, currently ~501k circulating.
- USDso is part of the Frax FraxNet branded-stablecoin program, collateralised 1:1 by frxUSD held in a Frax-operated BrandedCustodian on Somnia.
- Two-file change: new `src/adapters/peggedAssets/usd-somnia/index.ts` reading `erc20:totalSupply`, and new entry `id: "377"` in `src/peggedData/peggedData.ts` with `module: "usd-somnia"` (not yet on CoinGecko) and `priceSource: "defillama"`.

## Test plan
- [x] `pnpm test usd-somnia peggedUSD` from repo root prints circulating supply for `somnia` matching on-chain `totalSupply()` (Somnia mainnet RPC: `https://api.infra.mainnet.somnia.network`).

Verified locally: adapter output `~501.07k` matches the on-chain `totalSupply()` reading.

Linear: DEX-530

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * USD Somnia (USDso) support has been integrated for the Somnia network. This fiat-backed USD pegged asset provides comprehensive price tracking and monitoring capabilities. Users can now seamlessly interact with and track the asset value within the Somnia blockchain ecosystem. Real-time pricing data ensures accurate and current asset valuations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->