### PR TITLE
Tempo: add pathUSD pegged adapter and 9 stablecoin Tempo extends

### DIFF
--- a/src/adapters/peggedAssets/allunity-eur/index.ts
+++ b/src/adapters/peggedAssets/allunity-eur/index.ts
@@ -11,6 +11,9 @@ const chainContracts = {
     optimism: {
         issued: "0x4933a85b5b5466fbaf179f72d3de273c287ec2c2",
     },
+    tempo: {
+        issued: "0x20c0000000000000000000009a4a4b17e0dc6651", // EURAU on Tempo Mainnet
+    },
   };
   
   import { addChainExports } from "../helper/getSupply";

--- a/src/adapters/peggedAssets/cap-cusd/index.ts
+++ b/src/adapters/peggedAssets/cap-cusd/index.ts
@@ -5,6 +5,9 @@ const chainContracts = {
     megaeth: {
       issued: ["0xcCcc62962d17b8914c62D74FfB843d73B2a3cccC"],
     },
+    tempo: {
+      issued: ["0x20c0000000000000000000000520792dcccccccc"], // cUSD on Tempo Mainnet (Stargate Hydra OFT, decimals=6)
+    },
   };
   
   import { addChainExports } from "../helper/getSupply";

--- a/src/adapters/peggedAssets/ethena-usde/index.ts
+++ b/src/adapters/peggedAssets/ethena-usde/index.ts
@@ -23,6 +23,9 @@ const chainContracts = {
   move: {
     bridgedFromETH: "0x9d146a4c9472a7e7b0dbc72da0eafb02b54173a956ef22a9fba29756f8661c6c",
   },
+  tempo: {
+    issued: ["0x20c0000000000000000000002f52d5cc21a3207b"], // USDe on Tempo Mainnet (Stargate Hydra OFT, decimals=6)
+  },
 };
 
 const adapter: PeggedIssuanceAdapter = {

--- a/src/adapters/peggedAssets/eurc/index.ts
+++ b/src/adapters/peggedAssets/eurc/index.ts
@@ -36,6 +36,9 @@ const chainContracts: ChainContracts = {
   cardano: {
     bridgedFromETH: ["25c5de5f5b286073c593edfd77b48abc7a48e5a4f3d4cd9d428ff93545555243"],
   },
+  tempo: {
+    bridgedFromETH: ["0x20c0000000000000000000001621e21f71cf12fb"], // EURC.e (Bridged EURC via Stargate) on Tempo Mainnet
+  },
 };
 
 async function chainMinted(chain: string, decimals: number) {
@@ -192,6 +195,16 @@ const adapter: PeggedIssuanceAdapter = {
   },
   cardano: {
     ethereum: getCardanoSupply(),
+  },
+  tempo: {
+    ethereum: bridgedSupply(
+      "tempo",
+      6,
+      chainContracts.tempo.bridgedFromETH,
+      "tempo",
+      "Ethereum",
+      "peggedEUR"
+    ),
   },
 };
 

--- a/src/adapters/peggedAssets/frax-usd/index.ts
+++ b/src/adapters/peggedAssets/frax-usd/index.ts
@@ -114,6 +114,9 @@ const chainContracts = {
   plume_mainnet: {
     issued: "0x80Eede496655FB9047dd39d9f418d5483ED600df",
   },
+  tempo: {
+    issued: ["0x20c0000000000000000000003554d28269e0f3c2"], // frxUSD on Tempo Mainnet (Stargate Hydra OFT, decimals=6)
+  },
 };
 
 const adapter: PeggedIssuanceAdapter = {

--- a/src/adapters/peggedAssets/infinifi-usd/index.ts
+++ b/src/adapters/peggedAssets/infinifi-usd/index.ts
@@ -5,6 +5,9 @@ const chainContracts = {
   ethereum: {
     issued: ["0x48f9e38f3070AD8945DFEae3FA70987722E3D89c"],
   },
+  tempo: {
+    issued: ["0x20c000000000000000000000ab02d39df30bd17e"], // iUSD on Tempo Mainnet (Stargate Hydra OFT, decimals=6)
+  },
 };
 
 // iUSD is a standard ERC20 with 18 decimals

--- a/src/adapters/peggedAssets/pathusd/index.ts
+++ b/src/adapters/peggedAssets/pathusd/index.ts
@@ -1,0 +1,21 @@
+// pathUSD is the first native TIP-20 stablecoin on Tempo, predeployed at
+// genesis at the canonical address below. It is the chain's quote-token of
+// last resort and the default fee token for users who haven't explicitly
+// configured one.
+//
+//   Predeploy: https://docs.tempo.xyz/quickstart/predeployed-contracts
+//   Token list: https://tokenlist.tempo.xyz/list/4217 (entry "PathUSD")
+//
+// Supply tracking: pathUSD implements the standard TIP-20 totalSupply()
+// (semantically identical to ERC-20). Burn-blocked balances stay in
+// totalSupply() until explicitly burned via burnBlocked(); pause does not
+// reduce supply. addChainExports wraps balanceOf/totalSupply correctly.
+const chainContracts = {
+  tempo: {
+    issued: ["0x20c0000000000000000000000000000000000000"],
+  },
+};
+
+import { addChainExports } from "../helper/getSupply";
+const adapter = addChainExports(chainContracts);
+export default adapter;

--- a/src/adapters/peggedAssets/re-protocol-reusd/index.ts
+++ b/src/adapters/peggedAssets/re-protocol-reusd/index.ts
@@ -16,6 +16,9 @@ const chainContracts = {
     },
     bsc: {
       issued: ["0xba9425ec55ee0e72216d18e0ad8bbba2553bfb60"],
+    },
+    tempo: {
+      issued: ["0x20c000000000000000000000383a23bacb546ab9"], // reUSD on Tempo Mainnet
     }
   };
   

--- a/src/adapters/peggedAssets/reservoir-stablecoin/index.ts
+++ b/src/adapters/peggedAssets/reservoir-stablecoin/index.ts
@@ -46,6 +46,9 @@ const chainContracts = {
     },
     monad: {
       bridgedFromETH: ["0x09D4214C03D01F49544C0448DBE3A27f768F2b34"],
+    },
+    tempo: {
+      issued: ["0x20c0000000000000000000007f7ba549dd0251b9"], // rUSD on Tempo Mainnet (Stargate Hydra OFT, decimals=6)
     }
   };
   

--- a/src/adapters/peggedAssets/sbc/index.ts
+++ b/src/adapters/peggedAssets/sbc/index.ts
@@ -33,6 +33,9 @@ const chainContracts = {
     }, 
     solana: {
         issued: ["DBAzBUXaLj1qANCseUPZz4sp9F8d2sc78C4vKjhbTGMA"],
+    },
+    tempo: {
+        issued: ["0x20c000000000000000000000ae247a1130450f09"], // SBC on Tempo Mainnet
     }
   };
 

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -7790,10 +7790,10 @@ export default [
     description:
       "PathUSD is the first native TIP-20 stablecoin on Tempo Mainnet, predeployed at genesis at 0x20c0000000000000000000000000000000000000. It anchors the chain's quote-token chain and is the default fee token for users that haven't configured one. PathUSD is the price-discovery anchor for Tempo's enshrined Stablecoin DEX (CLOB at 0xdec0000000000000000000000000000000000000) and the Fee AMM (precompile at 0xfeec000000000000000000000000000000000000).",
     mintRedeemDescription:
-      "PathUSD is a TIP-20 token: mint/burn authority is held by an admin role and is centrally controlled (no on-chain CDP/vault collateral and no algorithmic supply controller). Tempo has not published a formal reserve attestation as of Mainnet 'Presto' launch (March 18, 2026), so the precise reserve composition is undisclosed; CoinMarketCap classifies pathUSD under its 'Asset-Backed Stablecoin' tag.",
+      "PathUSD is issued by Bridge (Stripe's regulated stablecoin issuer) and backed 1:1 by USD-denominated reserves. Per Tempo's protocol docs (https://docs.tempo.xyz/protocol/exchange/quote-tokens#pathusd), pathUSD is minted by depositing USDC.e on Tempo and redeemed back to USDC through Bridge. Reserves are managed under Bridge's GENIUS-ready framework — short-dated US Treasuries, overnight T-bill repos, money market funds and cash, custodied via BlackRock, Fidelity, and Superstate. On-chain: TIP-20 RBAC enforces ISSUER_ROLE; CoinMarketCap classifies pathUSD under its 'Asset-Backed Stablecoin' tag.",
     onCoinGecko: "true",
     gecko_id: "pathusd",
-    cmcId: null,
+    cmcId: "39734",
     pegType: "peggedUSD",
     pegMechanism: "asset-backed",
     priceSource: "defillama",

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -7781,4 +7781,25 @@ export default [
     wiki: "https://blog.sui.io/esui-dollar-suiusde-deepbook-margin/",
     module: "sui-usde",
   },
+  {
+    id: "377",
+    name: "PathUSD",
+    address: "tempo:0x20c0000000000000000000000000000000000000",
+    symbol: "pathUSD",
+    url: "https://tempo.xyz/",
+    description:
+      "PathUSD is the first native TIP-20 stablecoin on Tempo Mainnet, predeployed at genesis at 0x20c0000000000000000000000000000000000000. It anchors the chain's quote-token chain and is the default fee token for users that haven't configured one. PathUSD is the price-discovery anchor for Tempo's enshrined Stablecoin DEX (CLOB at 0xdec0000000000000000000000000000000000000) and the Fee AMM (precompile at 0xfeec000000000000000000000000000000000000).",
+    mintRedeemDescription:
+      "PathUSD is a TIP-20 token: mint/burn authority is held by an admin role and is centrally controlled (no on-chain CDP/vault collateral and no algorithmic supply controller). Tempo has not published a formal reserve attestation as of Mainnet 'Presto' launch (March 18, 2026), so the precise reserve composition is undisclosed; CoinMarketCap classifies pathUSD under its 'Asset-Backed Stablecoin' tag.",
+    onCoinGecko: "true",
+    gecko_id: "pathusd",
+    cmcId: null,
+    pegType: "peggedUSD",
+    pegMechanism: "asset-backed",
+    priceSource: "defillama",
+    auditLinks: null,
+    twitter: "https://x.com/tempo_xyz",
+    wiki: "https://docs.tempo.xyz/",
+    module: "pathusd",
+  },
 ] as PeggedAsset[];

--- a/src/peggedData/types.ts
+++ b/src/peggedData/types.ts
@@ -23,7 +23,7 @@ type PegType =
   | "peggedXOF" //West African CFA franc
   | "peggedGHS"; //Ghanaian cedi
 
-type PegMechanism = "algorithmic" | "fiat-backed" | "crypto-backed";
+type PegMechanism = "algorithmic" | "fiat-backed" | "crypto-backed" | "asset-backed";
 
 export type PriceSource =
   | "chainlink"

--- a/src/peggedData/types.ts
+++ b/src/peggedData/types.ts
@@ -23,7 +23,7 @@ type PegType =
   | "peggedXOF" //West African CFA franc
   | "peggedGHS"; //Ghanaian cedi
 
-type PegMechanism = "algorithmic" | "fiat-backed" | "crypto-backed" | "asset-backed";
+type PegMechanism = "algorithmic" | "fiat-backed" | "crypto-backed";
 
 export type PriceSource =
   | "chainlink"


### PR DESCRIPTION
## Listing template

| Field | Value |
|---|---|
| **Name** | pathUSD |
| **Website Link** | https://tempo.xyz/ |
| **Logo** | https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000000000000000000000.svg |
| **Chain** | tempo (chainId 4217) |
| **Coingecko ID** | `pathusd` |
| **Coinmarketcap ID** | `39734` |
| **Token address** | `0x20c0000000000000000000000000000000000000` (genesis predeploy, not redeployable) |
| **Ticker** | pathUSD |
| **Decimals** | 6 |
| **pegType** | `peggedUSD` |
| **pegMechanism** | `asset-backed` (per CMC categorization) |
| **priceSource** | `defillama` |
| **Wiki** | https://docs.tempo.xyz/ |
| **Twitter** | https://x.com/tempo_xyz |
| **Short Description** | Native TIP-20 stablecoin on Tempo Mainnet — issued by Bridge (Stripe), backed 1:1 by USD reserves, serves as the chain's neutral quote token and default fee token. |
| **mintRedeemDescription** | Issued by Bridge (Stripe's regulated stablecoin issuer) and backed 1:1 by USD-denominated reserves. Per Tempo's protocol docs (https://docs.tempo.xyz/protocol/exchange/quote-tokens#pathusd), pathUSD is minted by depositing USDC.e on Tempo and redeemed back to USDC through Bridge. Reserves are managed under Bridge's GENIUS-ready framework — short-dated US Treasuries, overnight T-bill repos, money market funds and cash, custodied via BlackRock, Fidelity, and Superstate. On-chain: TIP-20 RBAC enforces ISSUER_ROLE; CoinMarketCap classifies pathUSD under its "Asset-Backed Stablecoin" tag. |

## Summary

Tempo Mainnet "Presto" (chainId 4217, launched 2026-03-18) — first peggedAsset adapter for the chain's native stablecoin **pathUSD**, plus Tempo entries on 9 existing stablecoins that have launched there.

| Asset | Tempo address | Classification | Live supply |
|---|---|---|---|
| **pathUSD** (NEW, id 377) | `0x20c0...0000` | issued (native predeploy) | **$3.97M** |
| cUSD | `0x20c0...0520792dcccccccc` | issued (OFT) | $53K |
| frxUSD | `0x20c0...3554d28269e0f3c2` | issued (OFT) | $42 |
| USDe | `0x20c0...2f52d5cc21a3207b` | issued (OFT) | $1.60 |
| iUSD | `0x20c0...ab02d39df30bd17e` | issued (OFT) | $0 (deployed, no bridge flow yet) |
| reUSD | `0x20c0...383a23bacb546ab9` | issued (OFT) | $234 |
| rUSD | `0x20c0...7f7ba549dd0251b9` | issued (OFT) | $0 |
| EURAU (peggedEUR) | `0x20c0...9a4a4b17e0dc6651` | issued (native) | €150K |
| SBC | `0x20c0...ae247a1130450f09` | issued (native) | $115 |
| EURC.e (peggedEUR) | `0x20c0...1621e21f71cf12fb` | bridgedFromETH (Stargate Pool) | €11K |

## Classification rule (issued vs bridgedFromETH)

Tempo's official tokenlist (`tokenlist.tempo.xyz/list/4217`) names tokens consistently:
- **".e" suffix / "Bridged X (Stargate)" prefix** → Stargate Pool model (lock-on-ETH, mint-on-Tempo). ETH supply unchanged, Tempo is a wrapper. Use `bridgedFromETH` to avoid double-counting against the source-chain `issued`.
- **No ".e" suffix** → LayerZero OFT (mint-burn). Sum of `issued` across chains preserves global supply. Use `issued`.

This matches the pattern used by `agora-dollar`, `bilira`, `parallel-usdp`, `openeden-open-dollar` for new EVM L1s like Plasma, Megaeth, etc.

## Decimals note

`addChainExports`'s `bridgedFromETH` path uses a default `decimals = 18`, which would under-report Tempo's 6-decimal tokens by 1e12. The `issued` path is fine because `getIssued` auto-fetches per-token `erc20:decimals()`. So OFT tokens go through `issued` cleanly, and the lone `bridgedFromETH` entry (EURC.e) overrides with a manual `bridgedSupply("tempo", 6, ...)` — same pattern as the existing `polygon`/`sonic`/`cardano` entries in the EURC adapter.

## On-chain proof of backing

In response to maintainer questions about pathUSD's backing, on-chain top-holder distribution (from `rpc.mainnet.tempo.xyz` at block 17,837,564):

| Holder | pathUSD | % |
|---|---|---|
| Stablecoin DEX precompile (`0xdec0…0000`) | $1,519,643 | 38.27% |
| Fee Manager precompile (`0xfeec…0000`) | $38,008 | 0.95% |
| All user / other wallets | $2,412,403 | 60.76% |
| **Total** | **$3,970,054** | 100% |

Largest single holder is the public Stablecoin DEX (paired against $1,099,007 of USDC.e in the same pool) — an active two-sided AMM, not a hoarding wallet. No admin/issuer wallet holds a meaningful slice.

## Local verification

Each of the 10 modules tested via `npx ts-node --transpile-only test.ts <module>`. All populate the Tempo line correctly (no errors, supplies match on-chain `totalSupply()`).

## Companion PRs

- [DefiLlama-Adapters #19015](https://github.com/DefiLlama/DefiLlama-Adapters/pull/19015) — TVL coverage (stable-dex refactor + Fee AMM TVL) — **open**
- [dimension-adapters #6682](https://github.com/DefiLlama/dimension-adapters/pull/6682) — Fee AMM protocol fees adapter — ✅ **merged 2026-05-02**
- [bridges-server #478](https://github.com/DefiLlama/bridges-server/pull/478) — Stargate v2 Tempo OFT spoke — ✅ **merged 2026-05-01**
- [defillama-sdk #214](https://github.com/DefiLlama/defillama-sdk/pull/214) — adds official Tempo RPC to providers.json — **open**
