### PR TITLE
Add iUSD on Initia

### DIFF
--- a/src/adapters/peggedAssets/helper/chains.json
+++ b/src/adapters/peggedAssets/helper/chains.json
@@ -107,6 +107,7 @@
   "icon",
   "icp",
   "imx",
+  "initia",
   "injective",
   "ink",
   "iotaevm",

--- a/src/adapters/peggedAssets/initia-iUSD/index.ts
+++ b/src/adapters/peggedAssets/initia-iUSD/index.ts
@@ -1,0 +1,18 @@
+import { cosmosSupply } from "../helper/getSupply";
+import { PeggedIssuanceAdapter } from "../peggedAsset.type";
+
+const iUSDDenom =
+  "move/6c69733a9e722f3660afb524f89fce957801fa7e4408b8ef8fe89db9627b570e";
+
+function initiaSupply() {
+  return cosmosSupply("initia", [iUSDDenom], 6, "", "peggedUSD");
+}
+
+const adapter: PeggedIssuanceAdapter = {
+  initia: {
+    minted: initiaSupply(),
+    unreleased: async () => ({}),
+  },
+};
+
+export default adapter;

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -7995,4 +7995,25 @@ export default [
     wiki: "https://tetradg.com/cadd-stablecoin/",
     module: "cad-digital",
   },
+  {
+    id: "388",
+    name: "Initia USD",
+    address: "initia:move/6c69733a9e722f3660afb524f89fce957801fa7e4408b8ef8fe89db9627b570e",
+    symbol: "iUSD",
+    url: "https://initia.xyz/",
+    description:
+      "iUSD is the native stablecoin of the Initia network, backed 1:1 by Agora's AUSD bridged to Initia via LayerZero. Unlike traditional stablecoins where the yield from reserves accrues to the issuer, iUSD's yield flows back into the Initia ecosystem.",
+    mintRedeemDescription:
+      "iUSD is minted on Initia 1:1 against AUSD bridged in via LayerZero from Ethereum and Arbitrum. Holders can redeem iUSD by burning it on Initia to unlock the underlying AUSD, which can then be redeemed for USD through Agora.",
+    onCoinGecko: "false",
+    gecko_id: null,
+    cmcId: null,
+    pegType: "peggedUSD",
+    pegMechanism: "fiat-backed",
+    priceSource: "defillama",
+    auditLinks: null,
+    twitter: "https://x.com/initia",
+    wiki: null,
+    module: "initia-iUSD",
+  },
 ] as PeggedAsset[];

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8005,8 +8005,8 @@ export default [
       "iUSD is the native stablecoin of the Initia network, backed 1:1 by Agora's AUSD bridged to Initia via LayerZero. Unlike traditional stablecoins where the yield from reserves accrues to the issuer, iUSD's yield flows back into the Initia ecosystem.",
     mintRedeemDescription:
       "iUSD is minted on Initia 1:1 against AUSD bridged in via LayerZero from Ethereum and Arbitrum. Holders can redeem iUSD by burning it on Initia to unlock the underlying AUSD, which can then be redeemed for USD through Agora.",
-    onCoinGecko: "false",
-    gecko_id: null,
+    onCoinGecko: "true",
+    gecko_id: "iusd",
     cmcId: null,
     pegType: "peggedUSD",
     pegMechanism: "fiat-backed",

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -7997,10 +7997,10 @@ export default [
   },
   {
     id: "388",
-    name: "Initia USD",
+    name: "iUSD",
     address: "initia:move/6c69733a9e722f3660afb524f89fce957801fa7e4408b8ef8fe89db9627b570e",
     symbol: "iUSD",
-    url: "https://initia.xyz/",
+    url: "https://app.testnet.initia.xyz/iusd",
     description:
       "iUSD is the native stablecoin of the Initia network, backed 1:1 by Agora's AUSD bridged to Initia via LayerZero. Unlike traditional stablecoins where the yield from reserves accrues to the issuer, iUSD's yield flows back into the Initia ecosystem.",
     mintRedeemDescription:

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8006,7 +8006,7 @@ export default [
     mintRedeemDescription:
       "iUSD is minted on Initia 1:1 against AUSD bridged in via LayerZero from Ethereum and Arbitrum. Holders can redeem iUSD by burning it on Initia to unlock the underlying AUSD, which can then be redeemed for USD through Agora.",
     onCoinGecko: "true",
-    gecko_id: "iusd",
+    gecko_id: "iusd-2",
     cmcId: null,
     pegType: "peggedUSD",
     pegMechanism: "fiat-backed",


### PR DESCRIPTION

##### Name (to be shown on DefiLlama): iUSD


##### Website Link: https://app.testnet.initia.xyz/iusd


##### Logo (High resolution, will be shown with rounded borders): https://github.com/initia-labs/initia-registry/blob/main/images/iUSD.png


##### Chain: Initia


##### Coingecko ID (leave empty if not listed): [(https://api.coingecko.com/api/v3/coins/list)](https://www.coingecko.com/en/coins/iusd)


##### Coinmarketcap ID (leave empty if not listed): 


##### Short Description: iUSD is Initia's native stablecoin, backed 1:1 by [[AUSD](https://www.agora.finance/)](https://www.agora.finance/) from Agora. Built for users, developers, and the Initia ecosystem.

##### mintRedeemDescription: iUSD is backed 1:1 by AUSD from Agora, a regulated digital finance infrastructure provider. According to Agora's disclosures, AUSD reserves include traditional currency, and cash equivalents (such as short-term U.S. Treasury securities and overnight reverse repurchase agreements), and other U.S. Dollar-denominated assets, which may include regulated stablecoins (such as USDC) and tokenized fixed income products.


##### Token address and ticker: move/6c69733a9e722f3660afb524f89fce957801fa7e4408b8ef8fe89db9627b570e, iUSD


##### pegType: peggedUSD

##### pegMechanism: fiat-backed

##### priceSource: defillama

##### wiki:

##### Twitter Link: https://x.com/initia/status/2026643449521606719


##### List of audit links if any:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Initia network support and iUSD stablecoin visibility across the platform.
  * iUSD now appears in pegged assets with metadata and source information; supply/issuance metrics are available.
  * Platform recognizes Initia as a supported chain for pegged asset tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->