### PR TITLE
feat: add ethereum to ylds

### DIFF
--- a/src/adapters/peggedAssets/ylds/index.ts
+++ b/src/adapters/peggedAssets/ylds/index.ts
@@ -1,4 +1,4 @@
-import { addChainExports, cosmosSupply, solanaMintedOrBridged } from "../helper/getSupply";
+import { addChainExports, bridgedSupply, cosmosSupply, solanaMintedOrBridged } from "../helper/getSupply";
 import { Balances, ChainBlocks, PeggedIssuanceAdapter } from "../peggedAsset.type";
 import { getTotalSupply as stellarGetTotalSupply } from "../helper/stellar";
 import { sumSingleBalance } from "../helper/generalUtil";
@@ -21,26 +21,29 @@ async function stellarMinted(assetID: string) {
 }
 
 const solanawYLDSContract = ['8fr7WGTVFszfyNWRMXj6fRjZZAnDwmXwEpCrtzmUkdih']
-const stellarYLDSAsset = 'YLDS:GAC7MOPTQLQUM3KC24AW4GHS3RLF72LPEZO54AH7EZ6TSMGRB5SOAVH3'
+const ethereumWYLDSContract = ['0x6aD038cA6C04e885630851278ca0a856Ad9a66Cc']
 
 const chainContracts = {
-    sui: {
-        issued: ['0x08b5e9f5caa91bdeb119ce6fb044d44a533fd856bcecaa74fc705852d709f200::ylds::YLDS']
+    stellar: {
+        issued: ['YLDS:GAC7MOPTQLQUM3KC24AW4GHS3RLF72LPEZO54AH7EZ6TSMGRB5SOAVH3']
     }
 }
 
 // Use `addChainExports` to generate the final adapter with combined logic
 const adapter: PeggedIssuanceAdapter = {
     ...addChainExports(chainContracts),
+    ethereum: {
+        provenance: bridgedSupply('ethereum', 6, ethereumWYLDSContract)
+    },
     provenance: {
         minted: provenanceSupply(),
     },
-    stellar: {
-        minted: stellarMinted(stellarYLDSAsset)
-    },
     solana: {
         provenance: solanaMintedOrBridged(solanawYLDSContract)
-    }
+    },
+    stellar: {
+        minted: stellarMinted(chainContracts.stellar.issued[0]),
+    },
 };
 
 export default adapter;


### PR DESCRIPTION
Adds Ethereum bridged wYLDS to the YLDS pegged asset. Also removes SUI reporting as it remains at 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated YLDS token supply tracking configuration and logic across Ethereum, Solana, and Stellar networks to enhance data accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/peggedassets-server/pull/787)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->