### PR TITLE
Add M by M^0 on Monad

### DIFF
--- a/src/adapters/peggedAssets/m-by-m^0/index.ts
+++ b/src/adapters/peggedAssets/m-by-m^0/index.ts
@@ -41,6 +41,9 @@ const chainContracts = {
   hyperliquid: {
     bridgedFromETH: [M_TOKEN_ADDRESS],
   },
+  monad: {
+    bridgedFromETH: [M_TOKEN_ADDRESS],
+  },
 };
 
 const adapter: PeggedIssuanceAdapter = {


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.


---
(fill in below form only for new listings)

##### Name (to be shown on DefiLlama): 


##### Website Link:


##### Logo (High resolution, will be shown with rounded borders):


##### Chain:


##### Coingecko ID (leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description:

##### mintRedeemDescription:


##### Token address and ticker:


##### pegType:

##### pegMechanism:

##### priceSource:

##### wiki:

##### Twitter Link:


##### List of audit links if any:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for M token on the Monad chain, bridged from Ethereum.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/peggedassets-server/pull/797?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->