### PR TITLE
flexUSD: mark deadFrom (collapsed 2022, frozen supply counted at $166M)

### DIFF
--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -473,6 +473,7 @@ export default [
     twitter: "https://twitter.com/coinflexdotcom",
     wiki: "https://wiki.defillama.com/wiki/flexUSD",
     module: "flex-usd",
+    deadFrom: "2022-06-23",
   },
   {
     id: "22",


### PR DESCRIPTION
## Summary

`flexUSD` (id 21) is reported at **~\$166M circulating**, but the token collapsed with its issuer in 2022 and is worth **~\$12M** at its real market price. This adds `deadFrom: "2022-06-23"` so the dead supply stops being counted, matching how other wound-down assets (EURT, Acala aUSD) are handled.

## Why flexUSD is dead

- Its issuer **CoinFLEX halted withdrawals on 2022-06-23** ([CoinDesk](https://www.coindesk.com/business/2022/06/23/coinflex-pauses-withdrawals-amid-extreme-market-conditions-and-counterparty-uncertainty)), and flexUSD was **excluded** from the limited-withdrawal restart on 2022-07-14 ([CoinDesk](https://www.coindesk.com/business/2022/07/14/coinflex-restarts-withdrawals-with-10-limit)). The rebranded entity **OPNX shut down entirely on 2024-02-14** ([The Block](https://www.theblock.co/post/275695/crypto-derivatives-exchange-opnx-to-shut-down-in-february)). There is no issuer and no redemption path.
- On-chain the supply is frozen: over the **last 365 days the Ethereum contract had 0 mints, 0 burns and 10 transfers**.

## The data error

- `gecko_id` is `null` and `onCoinGecko` is `"false"`, so with no price feed the value falls back to the \$1 peg default.
- On-chain `totalSupply`: Ethereum `0xa774ffb4af6b0a91331c084e1aebae6ad535e6f3` = **92,590,161** + smartBCH `0x7b2b3c5308ab5b2a1d9a94d20d35ccdf61e05b72` = **73,760,084** = **166.35M flexUSD**, valued at ~\$1 → **~\$166M reported**.
- Real value: CoinGecko `flex-usd` = **~\$0.072**, market cap **~\$17.6M**. DefiLlama overstates flexUSD by ~\$148M.
- Most visible on the **smartBCH** chain page, whose entire ~\$73.7M stablecoin total is this single frozen asset.

## Fix

One line on the flexUSD entry: `deadFrom: "2022-06-23"` — the CoinFLEX withdrawal-halt / depeg date (when it stopped functioning as a stablecoin; the full OPNX shutdown was 2024-02-14). This routes flexUSD through the existing `deadFrom` skip in `storeNewPeggedBalances` / `storePegged`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pegged asset data to reflect deactivation status from June 23, 2022.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/peggedassets-server/pull/801?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->