### PR TITLE
Mark collapsed stablecoins deadFrom: fUSD, SpiceUSD, DigitalDollar (DUSD)

### DIFF
--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -1513,6 +1513,7 @@ export default [
     ],
     twitter: "https://twitter.com/fluid_fi/",
     wiki: "https://wiki.defillama.com/wiki/Fluid_Finance",
+    deadFrom: "2024-04-21",
   },
   {
     id: "71",

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -681,6 +681,7 @@ export default [
     auditLinks: null,
     twitter: "https://twitter.com/spicetradeai",
     wiki: "https://wiki.defillama.com/wiki/SpiceUSD_(USDS)",
+    deadFrom: "2022-11-20",
   },
   {
     id: "32",
@@ -1360,6 +1361,7 @@ export default [
     auditLinks: null,
     twitter: "https://twitter.com/fantomfdn/",
     wiki: "https://wiki.defillama.com/wiki/Fantom",
+    deadFrom: "2022-04-17",
   },
   {
     id: "64",


### PR DESCRIPTION
## Summary

Three long-dead stablecoins are still counted at the **\$1 peg default** because their `gecko_id` is `null` (no price feed). Each stopped being issued years ago and now trades near zero. This marks them `deadFrom` so the frozen supply stops inflating the stablecoin totals — same pattern as EURT / Acala aUSD.

| Asset | id | Reported (at \$1) | Real price | Last on-chain mint | Why dead |
|---|---|---|---|---|---|
| Fantom USD (fUSD) | 63 | ~\$18.9M | ~\$0.05 | **2022-04-17** | fMint/Fantom Finance wound down |
| SpiceUSD (USDS) | 31 | ~\$18.0M | ~\$0.014 | **2022-11-20** | algorithmic depeg, abandoned |
| DigitalDollar (DUSD) | 70 | ~\$2.95M | ~\$0.006 | **2024-04-21** | issuer Fluid Finance SA bankrupt 2024-04-22 |

## Evidence

**Fantom USD / fUSD** (`fantom:0xad84341756bf337f5a0164515b1f6f993d194e1f`) — fUSD is the fMint synthetic stablecoin; fMint was wound down in 2022. Last on-chain mint **2022-04-17**, **0 mints in the last 365 days**. Trades at ~\$0.05 today (CoinGecko) vs the \$1 default.

**SpiceUSD** (`avax:0xab05b04743e0aeaf9d2ca81e5d3b8385e4bf961e`, also BSC/Polygon/Ethereum) — algorithmic stablecoin that depegged and was abandoned. Last mint **2022-11-20**, **0 mints in the last 365 days**. Trades at ~\$0.014 today.

**DigitalDollar (DUSD)** (`arbitrum:0xf0b5ceefc89684889e5f7e0a7775bd100fcd3709`) — issuer **Fluid Finance SA was dissolved in bankruptcy on 2024-04-22** (Geneva commercial register; redemptions stopped). Last on-chain mint **2024-04-21** (the day before), **0 mints in the last 365 days**. Trades at ~\$0.006 today.

## Fix

`deadFrom` on each entry, set to the date issuance permanently ceased on-chain (last mint). This routes them through the existing `deadFrom` skip in `storeNewPeggedBalances` / `storePegged`, so the dead supply is no longer valued at \$1.