### PR TITLE
USP (Platypus): mark deadFrom — depegged in 2023 exploit, still counted at $65M

### DIFF
--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -2090,6 +2090,7 @@ export default [
     auditLinks: null,
     twitter: "https://twitter.com/Platypusdefi",
     deprecated: true,
+    deadFrom: "2023-02-16",
     wiki: null,
   },
   {


### PR DESCRIPTION
## Summary

Platypus **USP** (id 97) is reported at **~\$65M circulating**, but it lost its peg in the February 2023 exploit, was abandoned by the protocol, and trades at **~\$0.34** today — real value ~\$22M. It is already flagged `deprecated: true`, but that flag is display-only and does not stop the asset from being valued. This adds `deadFrom` so the dead supply stops being counted at the \$1 peg default.

## Why USP is dead

- USP lost its dollar peg in the **2023-02-16 flash-loan attack** on Platypus ([CoinDesk](https://www.coindesk.com/markets/2023/02/16/usp-stablecoin-loses-dollar-peg-as-defi-protocol-platypus-suffers-85m-attack)), dropping to ~\$0.48 and lower. Platypus later restarted the stableswap **without** USP.
- On-chain, USP has not been issued since: **last mint 2023-02-16** (the day of the exploit), **0 mints in the last 365 days**.
- Real price today ≈ **\$0.34** (CoinGecko), vs the \$1 default DefiLlama applies because `gecko_id` is `null`.

## Why it's still counted

`deprecated: true` is already set on this entry, but `deprecated` is only a metadata field — it isn't referenced in `storeNewPeggedBalances` / `storePegged`, so the asset keeps updating and is valued at the \$1 peg default. The field that actually stops a dead asset is `deadFrom` (e.g. Synnax `syUSD` carries both `deprecated: true` and `deadFrom`).

## Fix

Add `deadFrom: "2023-02-16"` (the depeg/last-mint date) to the USP entry, alongside the existing `deprecated: true`. This routes USP through the existing `deadFrom` skip, removing ~\$43M of phantom circulating valued at \$1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated metadata for USP Stablecoin to reflect its inactive status with a deactivation date.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/peggedassets-server/pull/803?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->