### PR TITLE
feat: add Citrea USDC.e and USDT.e bridged token tracking

### DIFF
--- a/src/adapters/peggedAssets/tether/config.ts
+++ b/src/adapters/peggedAssets/tether/config.ts
@@ -397,5 +397,8 @@ export const chainContracts: ChainContracts = {
   },
   mantra: {
     bridgedFromETH: ["0x3806640578b710d8480910bF51510bc538d2F51A"], 
+  },
+  citrea: {
+    bridgedFromETH: ["0x9f3096Bac87e7F03DC09b0B416eB0DF837304dc4"], // USDT.e
   }
 };

--- a/src/adapters/peggedAssets/tether/index.ts
+++ b/src/adapters/peggedAssets/tether/index.ts
@@ -1148,6 +1148,9 @@ const adapter: PeggedIssuanceAdapter = {
   mantra: {
     ethereum: bridgedSupply("mantra", 6, chainContracts.mantra.bridgedFromETH)
   },
+  citrea: {
+    ethereum: bridgedSupply("citrea", 6, chainContracts.citrea.bridgedFromETH), // USDT.e
+  },
 };
 
 export default adapter;

--- a/src/adapters/peggedAssets/usd-coin/config.ts
+++ b/src/adapters/peggedAssets/usd-coin/config.ts
@@ -534,5 +534,8 @@ export const chainContracts: ChainContracts = {
   },
   edgex: {
     issued: ["0x98d2919b9A214E6Fa5384AC81E6864bA686Ad74c"]
+  },
+  citrea: {
+    bridgedFromETH: ["0xE045e6c36cF77FAA2CfB54466D71A3aEF7bbE839"], // USDC.e
   }
 };


### PR DESCRIPTION
## Summary
Addresses DefiLlama/DefiLlama-Adapters#19584

Adds Citrea chain to USDC and USDT pegged asset adapters to enable the Bridged TVL section on defillama.com/chain/citrea

## Why this PR is in peggedassets-server
The Bridged TVL / chain-assets dataset is powered by peggedassets-server, not DefiLlama-Adapters. The issue was filed there but the actual fix belongs here where stablecoin supply tracking lives.

## Changes
- usd-coin/config.ts: USDC.e (0xE045e6c36cF77FAA2CfB54466D71A3aEF7bbE839) bridgedFromETH
- tether/config.ts + index.ts: USDT.e (0x9f3096Bac87e7F03DC09b0B416eB0DF837304dc4) bridgedFromETH

## Notes
- Citrea Chain ID: 4114
- WBTC.e (0xDF240DC08B0FdaD1d93b74d5048871232f6BEA3d) is not a pegged/stablecoin 
  asset,  it does not belong in peggedassets-server which only tracks 
  pegged assets (stablecoins, synthetic assets). WBTC tracking would 
  require a separate canonical token tracking system.
- Bridge volume adapters already exist in bridges-server 
  (citrea-usdc, citrea-usdt, citrea-wbtc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Tether (USDT) and USD Coin (USDC) on Citrea blockchain via Ethereum bridge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->