### PR TITLE
Add CHFm and JPYm on Monad

### DIFF
--- a/src/adapters/peggedAssets/mento-japanese-yen/index.ts
+++ b/src/adapters/peggedAssets/mento-japanese-yen/index.ts
@@ -4,6 +4,9 @@ const chainContracts: ChainContracts = {
   celo: {
     issued: ["0xc45ecf20f3cd864b32d9794d6f76814ae8892e20"],
   },
+  monad: {
+    issued: ["0x22f6A6752800eAB67b84748FeFc3cC658384aF72"],
+  }
 };
 
 import { addChainExports } from "../helper/getSupply";

--- a/src/adapters/peggedAssets/mento-swiss-franc/index.ts
+++ b/src/adapters/peggedAssets/mento-swiss-franc/index.ts
@@ -4,6 +4,9 @@ const chainContracts: ChainContracts = {
   celo: {
     issued: ["0xb55a79F398E759E43C95b979163f30eC87Ee131D"],
   },
+  monad: {
+    issued: ["0xF64e91fFEf7ef43aA314F0Bc2AC39f770797990C"],
+  }
 };
 
 import { addChainExports } from "../helper/getSupply";


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.


---
(fill in below form only for new listings)

##### Name (to be shown on DefiLlama): 


##### Website Link:


##### Logo (High resolution, will be shown with rounded borders):


##### Chain:


##### Coingecko ID (leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description:

##### mintRedeemDescription:


##### Token address and ticker:


##### pegType:

##### pegMechanism:

##### priceSource:

##### wiki:

##### Twitter Link:


##### List of audit links if any:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Mento Japanese Yen (JPY) support on Monad chain
  * Enabled Mento Swiss Franc (CHF) support on Monad chain

<!-- end of auto-generated comment: release notes by coderabbit.ai -->