### PR TITLE
USDR (Real USD): mark deadFrom — collapsed Oct 2023, still counted at ~$19M face

### DIFF
--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -1834,6 +1834,7 @@ export default [
     pegMechanism: "algorithmic",
     priceSource: "coingecko",
     auditLinks: null,
+    deadFrom: "2023-10-11",
     twitter: "https://twitter.com/tangibleDAO",
     wiki: "https://wiki.defillama.com/wiki/Tangible",
   },


### PR DESCRIPTION
### Problem
Real USD (USDR, id 85, Tangible) is counted at $1 face value (~$18.8M circulating) in the pegged-asset total, but it is no longer a dollar stablecoin.

USDR depegged on **2023-10-11** when a run on its reserves drained the liquid DAI backing (the rest was illiquid tokenized real estate). It fell ~46% to ~$0.52 in a day and never recovered — it trades around **$0.42** today, and Tangible wound the product down into an asset-redemption process.

Because the adapter sums circulating supply at the $1 peg regardless of market price, USDR keeps contributing ~$18.8M of phantom value to the stablecoin total.

### Fix
Set `deadFrom: "2023-10-11"` (the depeg date) on the Real USD entry. This stops it from being counted from the collapse onward while preserving the historical data, consistent with how other collapsed stablecoins (flexUSD, fUSD, SpiceUSD, USP) are handled.

### Verification
- Current market price ~$0.42 across the remaining Polygon/Pearl USDR pools (liquidity is now only a few $10k).
- Depeg widely reported (DL News, CCN, MEXC, Flywheel DeFi) on 2023-10-11; no recovery since.
- Single-line change to the registry entry; supply logic untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated "Real USD" asset metadata to mark it as inactive starting October 11, 2023.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->