### PR TITLE
USDN (Neutrino): mark deadFrom — peg abandoned / rebranded to XTN, still counted at ~$22.7M face

### DIFF
--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -282,6 +282,7 @@ export default [
     pegMechanism: "algorithmic",
     priceSource: "defillama",
     auditLinks: null,
+    deadFrom: "2023-02-01",
     twitter: "https://twitter.com/neutrino_proto",
     wiki: "https://wiki.defillama.com/wiki/Neutrino",
   },


### PR DESCRIPTION
### Problem
Neutrino USD (USDN, id 12) is counted at $1 face value (~$22.7M circulating) in the pegged-asset total, but it is no longer a dollar stablecoin.

USDN depegged during 2022 and never recovered. In **early February 2023** a Neutrino governance vote abandoned the $1 peg and rebranded USDN to **XTN** — a free-floating "Neutrino Index Token" backed by a basket of assets (per Neutrino's own XTN litepaper), explicitly not pegged to the dollar. XTN trades around **$0.05** today.

Because the adapter sums circulating supply at the $1 peg regardless of market price, this dead peg keeps adding ~$22.7M of phantom value to the stablecoin total.

### Fix
Set `deadFrom: "2023-02-01"` (the peg-abandonment / XTN rebrand) on the Neutrino entry, consistent with how other collapsed stablecoins (flexUSD, fUSD, SpiceUSD, USP) are handled.

A previous PR (#269) proposed *deleting* the USDN entry and was declined in order to keep the historical data. `deadFrom` is the better fit for exactly that reason: it keeps the entry and all of its history intact and only stops it from being counted at $1 from the rebrand onward — so the data is preserved while the phantom is removed.

### Verification
- Neutrino's USDN→XTN rebrand and peg abandonment (Feb 2023) are documented by the project and covered widely; CoinGecko/CMC now list the asset as "Neutrino Index Token (XTN)".
- Market price ~$0.05, no recovery.
- Single-line change to the registry entry; supply logic untouched.