### PR TITLE
beatusd: add Hyperbeat USD treasury-backed stablecoin supply adapter

### DIFF
--- a/src/adapters/peggedAssets/beatusd/index.ts
+++ b/src/adapters/peggedAssets/beatusd/index.ts
@@ -1,0 +1,9 @@
+const chainContracts = {
+  hyperliquid: {
+    issued: ["0x669abe85F96a9e3B34723F7Be9bC6F250aBC0Cc1"],
+  },
+};
+
+import { addChainExports } from "../helper/getSupply";
+const adapter = addChainExports(chainContracts);
+export default adapter;

--- a/src/adapters/peggedAssets/prices/index.ts
+++ b/src/adapters/peggedAssets/prices/index.ts
@@ -32,6 +32,5 @@ export async function getPrices(assets: any[]) {
   }
   finalRes["m-2"] = 1
   finalRes["terrausd"] = 0
-  finalRes["beatusd"] = 1 // beatUSD is a flat $1 token; DefiLlama has no price feed for it
   return finalRes
 }

--- a/src/adapters/peggedAssets/prices/index.ts
+++ b/src/adapters/peggedAssets/prices/index.ts
@@ -32,5 +32,6 @@ export async function getPrices(assets: any[]) {
   }
   finalRes["m-2"] = 1
   finalRes["terrausd"] = 0
+  finalRes["beatusd"] = 1 // beatUSD is a flat $1 token; DefiLlama has no price feed for it
   return finalRes
 }

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8221,7 +8221,7 @@ export default [
     name: "Hyperbeat USD",
     address: "hyperliquid:0x669abe85F96a9e3B34723F7Be9bC6F250aBC0Cc1",
     symbol: "beatUSD",
-    url: "https://www.hyperbeat.org/",
+    url: "https://hyperbeat.org/",
     description:
       "Hyperbeat USD (beatUSD) is a treasury-backed stablecoin issued on HyperEVM through Hyperbeat's Liquid banking accounts.",
     mintRedeemDescription:
@@ -8233,8 +8233,8 @@ export default [
     pegMechanism: "fiat-backed",
     priceSource: "defillama",
     auditLinks: null,
-    twitter: null,
-    wiki: null,
+    twitter: "https://x.com/hyperbeat",
+    wiki: "https://docs.hyperbeat.org",
     module: "beatusd",
     doublecounted: true,
   },

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8216,4 +8216,26 @@ export default [
     wiki: null,
     module: "usdead",
   },
+  {
+    id: "397",
+    name: "Hyperbeat USD",
+    address: "hyperliquid:0x669abe85F96a9e3B34723F7Be9bC6F250aBC0Cc1",
+    symbol: "beatUSD",
+    url: "https://www.hyperbeat.org/",
+    description:
+      "Hyperbeat USD (beatUSD) is a treasury-backed stablecoin issued on HyperEVM through Hyperbeat's Liquid banking accounts.",
+    mintRedeemDescription:
+      "Every dollar deposited into a Hyperbeat Liquid banking account mints Hyperbeat USD, a treasury backed stablecoin.",
+    onCoinGecko: "false",
+    gecko_id: "beatusd",
+    cmcId: null,
+    pegType: "peggedUSD",
+    pegMechanism: "fiat-backed",
+    priceSource: "defillama",
+    auditLinks: null,
+    twitter: null,
+    wiki: null,
+    module: "beatusd",
+    doublecounted: true,
+  },
 ] as PeggedAsset[];


### PR DESCRIPTION
…on HyperEVM

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.


---
(fill in below form only for new listings)

##### Name (to be shown on DefiLlama): 
Hyperbeat USD

##### Website Link:
https://hyperbeat.org/

##### Logo (High resolution, will be shown with rounded borders):
<img width="600" height="600" alt="USD" src="https://github.com/user-attachments/assets/e9b45699-093e-4109-8ce9-957b2decb717" />

##### Chain:
hyperevm

##### Coingecko ID (leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description:
  Hyperbeat USD (beatUSD) is a treasury-backed stablecoin issued on HyperEVM through Hyperbeat's Liquid banking
  accounts.

  ##### mintRedeemDescription:
  Every dollar deposited into a Hyperbeat Liquid banking account mints Hyperbeat USD, a treasury backed stablecoin.

  ##### Token address and ticker:
  beatUSD - hyperliquid:0x669abe85F96a9e3B34723F7Be9bC6F250aBC0Cc1

  ##### pegType:
  peggedUSD

  ##### pegMechanism:
  fiat-backed

  ##### priceSource:
  defillama

  ##### wiki:
  https://docs.hyperbeat.org

  ##### Twitter Link:
https://x.com/hyperbeat


##### List of audit links if any:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Hyperbeat USD (beatUSD), a treasury-backed stablecoin on HyperEVM.
  * Implemented pricing mechanism for beatUSD with a fixed 1 USD price point.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->