### PR TITLE
Add USDV pegged asset

### DIFF
--- a/src/adapters/peggedAssets/usdv/index.ts
+++ b/src/adapters/peggedAssets/usdv/index.ts
@@ -45,8 +45,7 @@ async function minted() {
   const obligations = result.obligations || {};
 
   return {
-    peggedUSD: Number(obligations[USDV_CURRENCY] || obligations.USDV || 0),
-  };
+peggedUSD: Number(obligations[USDV_CURRENCY] || 0),  };
 }
 
 const adapter: PeggedIssuanceAdapter = {

--- a/src/adapters/peggedAssets/usdv/index.ts
+++ b/src/adapters/peggedAssets/usdv/index.ts
@@ -1,98 +1,58 @@
-const sdk = require("@defillama/sdk");
-import { sumSingleBalance } from "../helper/generalUtil";
-import { bridgedSupply } from "../helper/getSupply";
-import {
-  ChainBlocks,
-  PeggedIssuanceAdapter,
-  Balances,  ChainContracts,
-} from "../peggedAsset.type";
+import { PeggedIssuanceAdapter } from "../peggedAsset.type";
 
+const XRPL_RPC = "https://s1.ripple.com:51234/";
 
-const chainContracts: ChainContracts = {
-  ethereum: {
-    issued: ["0x0E573Ce2736Dd9637A0b21058352e1667925C7a8"],
-  },
-  bsc: {
-    bridgedFromETH: ["0x323665443CEf804A3b5206103304BD4872EA4253"],
-  },
-  optimism: {
-    bridgedFromETH: ["0x323665443CEf804A3b5206103304BD4872EA4253"],
-  },
-  arbitrum: {
-    bridgedFromETH: ["0x323665443CEf804A3b5206103304BD4872EA4253"],
-  },
-  avax: {
-    bridgedFromETH: ["0x323665443CEf804A3b5206103304BD4872EA4253"],
-  },
-  polygon: {
-    bridgedFromETH: ["0x323665443CEf804A3b5206103304BD4872EA4253"],
-  },
-  tomochain: {
-    bridgedFromETH: ["0x323665443CEf804A3b5206103304BD4872EA4253"],
-  },
+const USDV_ISSUER = "rfffsukWALJB1PXYk7H8xkR6UJUDT8nMJE";
+const USDV_CURRENCY = "5553445600000000000000000000000000000000";
+
+type XrplGatewayBalancesResult = {
+  obligations?: Record<string, string>;
+  status?: string;
+  error?: string;
+  error_message?: string;
 };
 
-async function chainMinted(chain: string, decimals: number) {
-  return async function (
-    _timestamp: number,
-    _ethBlock: number,
-    _chainBlocks: ChainBlocks
-  ) {
-    let balances = {} as Balances;
-    for (let issued of chainContracts[chain].issued) {
-      const totalSupply = (
-        await sdk.api.abi.call({
-          abi: "erc20:totalSupply",
-          target: issued,
-          block: _chainBlocks?.[chain],
-          chain: chain,
-        })
-      ).output;
-      sumSingleBalance(
-        balances,
-        "peggedUSD",
-        totalSupply / 10 ** decimals,
-        "issued",
-        false
-      );
-    }
-    return balances;
+async function xrplRpc<T>(method: string, params: Record<string, unknown>): Promise<T> {
+  const response = await fetch(XRPL_RPC, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      method,
+      params: [params],
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`XRPL RPC HTTP ${response.status}`);
+  }
+
+  const json = await response.json();
+  const result = json.result as XrplGatewayBalancesResult | undefined;
+
+  if (!result || result.status === "error") {
+    throw new Error(result?.error_message || result?.error || "XRPL RPC failed");
+  }
+
+  return result as T;
+}
+
+async function minted() {
+  const result = await xrplRpc<XrplGatewayBalancesResult>("gateway_balances", {
+    account: USDV_ISSUER,
+    ledger_index: "validated",
+  });
+
+  const obligations = result.obligations || {};
+
+  return {
+    peggedUSD: Number(obligations[USDV_CURRENCY] || obligations.USDV || 0),
   };
 }
 
 const adapter: PeggedIssuanceAdapter = {
-  ethereum: {
-    minted: chainMinted("ethereum", 6),
-  },
-  bsc: {
-    minted: bridgedSupply("bsc", 6, chainContracts.bsc.bridgedFromETH),
-  },
-  optimism: {
-    minted: bridgedSupply(
-      "optimism",
-      6,
-      chainContracts.optimism.bridgedFromETH
-    ),
-  },
-  arbitrum: {
-    minted: bridgedSupply(
-      "arbitrum",
-      6,
-      chainContracts.arbitrum.bridgedFromETH
-    ),
-  },
-  polygon: {
-    minted: bridgedSupply("polygon", 6, chainContracts.polygon.bridgedFromETH),
-  },
-  tomochain: {
-    minted: bridgedSupply(
-      "tomochain",
-      6,
-      chainContracts.tomochain.bridgedFromETH
-    ),
-  },
-  avax: {
-    minted: bridgedSupply("avax", 6, chainContracts.avax.bridgedFromETH),
+  ripple: {
+    minted,
+    unreleased: async () => ({}),
   },
 };
 

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8237,7 +8237,8 @@ export default [
     wiki: "https://docs.hyperbeat.org",
     module: "beatusd",
     doublecounted: true,
- {
+  },
+  {
     id: "398",
     name: "Valtorum USD",
     address: null,

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8216,18 +8216,18 @@ export default [
     wiki: null,
     module: "usdead",
   },
-    {
-    id: "397",
-    name: "USDV",
+   {
+    id: "398",
+    name: "Valtorum USD",
     address: null,
     symbol: "USDV",
     url: "https://valtorum.com",
     description:
-      "USDV is a USD-pegged stablecoin issued by Valtorum on the XRP Ledger.",
+      "Valtorum USD (USDV) is a permissioned USD-pegged stablecoin issued by Valtorum on the XRP Ledger. Holder trustlines require issuer authorization.",
     mintRedeemDescription:
-      "USDV is issued and redeemed by Valtorum through its XRP Ledger issuer account.",
+      "Valtorum USD is issued and redeemed by Valtorum through its XRP Ledger issuer account.",
     onCoinGecko: "false",
-    gecko_id: "usdv",
+    gecko_id: null,
     cmcId: null,
     pegType: "peggedUSD",
     pegMechanism: "fiat-backed",

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8232,6 +8232,11 @@ export default [
     pegType: "peggedUSD",
     pegMechanism: "fiat-backed",
     priceSource: "defillama",
+    auditLinks: null,
+    twitter: "https://x.com/hyperbeat",
+    wiki: "https://docs.hyperbeat.org",
+    module: "beatusd",
+    doublecounted: true,
  {
     id: "398",
     name: "Valtorum USD",

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8216,4 +8216,25 @@ export default [
     wiki: null,
     module: "usdead",
   },
+    {
+    id: "397",
+    name: "USDV",
+    address: null,
+    symbol: "USDV",
+    url: "https://valtorum.com",
+    description:
+      "USDV is a USD-pegged stablecoin issued by Valtorum on the XRP Ledger.",
+    mintRedeemDescription:
+      "USDV is issued and redeemed by Valtorum through its XRP Ledger issuer account.",
+    onCoinGecko: "false",
+    gecko_id: "usdv",
+    cmcId: null,
+    pegType: "peggedUSD",
+    pegMechanism: "fiat-backed",
+    priceSource: "defillama",
+    auditLinks: [],
+    twitter: null,
+    wiki: null,
+    module: "usdv",
+  },
 ] as PeggedAsset[];


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

(fill in below form only for new listings)

##### Name (to be shown on DefiLlama):
Valtorum USD

##### Website Link:
https://valtorum.com

##### Logo (High resolution, will be shown with rounded borders):
https://valtorum.com/usdv.png

##### Chain:
XRP Ledger / Ripple

##### Coingecko ID (leave empty if not listed):


##### Coinmarketcap ID (leave empty if not listed):

##### Short Description:
Valtorum USD (USDV) is a permissioned USD-pegged stablecoin issued by Valtorum on the XRP Ledger. Holder trustlines require issuer authorization.

##### Token address and ticker if any:
Issuer: `rfffsukWALJB1PXYk7H8xkR6UJUDT8nMJE`
Currency: `5553445600000000000000000000000000000000`
Ticker: USDV

##### Category:
Stablecoin

##### Oracle used:
On-chain XRPL issuer obligations via `gateway_balances`.

##### forkedFrom:
None

##### methodology:
The adapter reads XRPL on-chain issuer obligations using the `gateway_balances` method against a validated ledger. The USDV supply is returned as `peggedUSD`.

The adapter does not rely on off-chain APIs or manually maintained supply figures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added Valtorum USD (USDV), a fiat-backed USD pegged stablecoin on XRP Ledger, including real-time tracking of issued (minted) amounts.

## Updates
* USDV is now supported exclusively on XRP Ledger.
* Removed support from Ethereum, BSC, Optimism, Arbitrum, Polygon, TomoChain, and Avalanche.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->