### PR TITLE
Add Agant GBP stablecoin

### DIFF
--- a/src/adapters/peggedAssets/agant-gbp/index.ts
+++ b/src/adapters/peggedAssets/agant-gbp/index.ts
@@ -1,0 +1,20 @@
+import { addChainExports } from "../helper/getSupply";
+import type { ChainContracts } from "../peggedAsset.type";
+
+const chainContracts: ChainContracts = {
+  ethereum: {
+    issued: ["0xbBe6aAB0Ed76e90AeA0d1cd978EC231c8AdCDF8b"],
+  },
+  base: {
+    issued: ["0xbBe6aAB0Ed76e90AeA0d1cd978EC231c8AdCDF8b"],
+  },
+  solana: {
+    issued: ["DYoCmA91VE8REbWNw3kM736PN7vv97qc2jr5wmUbuNtZ"],
+  },
+  tempo: {
+    issued: ["0x20C0000000000000000000000a6Da882d075a4C3"],
+  },
+};
+
+const adapter = addChainExports(chainContracts, undefined, { pegType: "peggedGBP" });
+export default adapter;

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8259,4 +8259,25 @@ export default [
     wiki: "https://valtorum.com/about/",
     module: "valtorum-usdv",
   },
+  {
+    id: "399",
+    name: "Agant GBP",
+    address: "0xbBe6aAB0Ed76e90AeA0d1cd978EC231c8AdCDF8b",
+    symbol: "GBPA",
+    url: "https://www.agant.io/gbpa",
+    description:
+      "Agant GBP (GBPA) is a pound sterling stablecoin issued by Agant Finance Limited, a UK-based issuer registered with the UK Financial Conduct Authority as a cryptoasset firm under the Money Laundering Regulations (FRN: 1037671). GBPA is designed to be fully backed and redeemable 1:1 for pound sterling, and used for GBP-denominated payments, settlement, treasury operations, and on-chain financial applications.",
+    mintRedeemDescription:
+      "Eligible clients can exchange GBP for GBPA and redeem GBPA for GBP through Agant Finance Limited, subject to Agant's terms, onboarding requirements, compliance checks, and applicable regulatory obligations.",
+    onCoinGecko: "true",
+    gecko_id: "agant-gbp",
+    cmcId: null,
+    pegType: "peggedGBP",
+    pegMechanism: "fiat-backed",
+    priceSource: "defillama",
+    auditLinks: null,
+    twitter: "https://twitter.com/AgantFinance",
+    wiki: "https://docs.agant.io/XDREhsGKwMiuddKPr5Rt",
+    module: "agant-gbp",
+  },
 ] as PeggedAsset[];


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
Agant GBP

##### Website Link:
https://www.agant.io/gbpa

##### Logo (High resolution, will be shown with rounded borders):
https://www.agant.io/token-metadata/gbpa.png

##### Chain:
Ethereum, Base, Solana, Tempo

##### Coingecko ID (leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)
agant-gbp

##### Coinmarketcap ID (leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description:
Agant GBP (GBPA) is a pound sterling stablecoin issued by Agant Finance Limited, a UK-based issuer registered with the UK Financial Conduct Authority as a cryptoasset firm under the Money Laundering Regulations (FRN: 1037671).

##### mintRedeemDescription:
Eligible clients can exchange GBP for GBPA and redeem GBPA for GBP through Agant Finance Limited, subject to Agant's terms, onboarding requirements, compliance checks, and applicable regulatory obligations.

##### Token address and ticker:
GBPA

Ethereum/Base: 0xbBe6aAB0Ed76e90AeA0d1cd978EC231c8AdCDF8b
Solana: DYoCmA91VE8REbWNw3kM736PN7vv97qc2jr5wmUbuNtZ
Tempo: 0x20C0000000000000000000000a6Da882d075a4C3

##### pegType:
peggedGBP

##### pegMechanism:
fiat-backed

##### priceSource:
defillama

##### wiki:
https://docs.agant.io/XDREhsGKwMiuddKPr5Rt

##### Twitter Link:
https://twitter.com/AgantFinance

##### List of audit links if any:


##### Test:
`npx ts-node --transpile-only test.ts agant-gbp peggedGBP`

Total circulating: 450.01 k
All chains used real-time data with no extrapolation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Agant GBP (GBPA), a fiat-backed pegged asset, across Ethereum, Base, Solana, and Tempo networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->