### PR TITLE
update ctUSD

### DIFF
--- a/src/adapters/peggedAssets/m-by-m^0/index.ts
+++ b/src/adapters/peggedAssets/m-by-m^0/index.ts
@@ -1,8 +1,11 @@
-import { addChainExports, solanaMintedOrBridged } from "../helper/getSupply";
+import { ChainApi } from "@defillama/sdk";
+import { addChainExports, getApi, solanaMintedOrBridged } from "../helper/getSupply";
 import { cosmosSupply } from "../helper/getSupply";
-import { PeggedIssuanceAdapter } from "../peggedAsset.type";
+import { sumSingleBalance } from "../helper/generalUtil";
+import { Balances, PeggedIssuanceAdapter } from "../peggedAsset.type";
 
 const M_TOKEN_ADDRESS = "0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b";
+const CTUSD_ADDRESS = "0x8D82c4E3c936C7B5724A382a9c5a4E6Eb7aB6d5D";
 
 /**
  * M token is the native token of M^0 protocol on Ethereum, backed by U.S. Treasuries.
@@ -23,6 +26,21 @@ async function nobleUSDNAsBridgedM() {
     'ethereum',
     'peggedUSD'
   );
+}
+
+/**
+ * ctUSD on Citrea is fully backed 1:1 by M held in custody.
+ * Since ctUSD is counted on Citrea, we subtract its totalSupply from M on
+ * Ethereum to avoid double-counting the same T-bill backing.
+ */
+async function ctUSDBackingOffset() {
+  return async function (_api: ChainApi) {
+    const citreaApi = await getApi("citrea", _api);
+    const balances = {} as Balances;
+    const supply = await citreaApi.call({ abi: "erc20:totalSupply", target: CTUSD_ADDRESS });
+    sumSingleBalance(balances, "peggedUSD", Number(supply) / 1e6);
+    return balances;
+  };
 }
 
 const chainContracts = {
@@ -46,8 +64,14 @@ const chainContracts = {
   },
 };
 
+const baseAdapter = addChainExports(chainContracts, {}, { decimals: 6 });
+
 const adapter: PeggedIssuanceAdapter = {
-  ...addChainExports(chainContracts, {}, { decimals: 6 }),
+  ...baseAdapter,
+  ethereum: {
+    ...baseAdapter.ethereum,
+    unreleased: ctUSDBackingOffset(),
+  },
   solana: {
     ethereum: solanaMintedOrBridged(["mzerokyEX9TNDoK4o2YZQBDmMzjokAeN6M2g2S3pLJo"]),
   },

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -7278,7 +7278,10 @@ export default [
     twitter: "https://x.com/citrea_xyz",
     wiki: "https://docs.citrea.xyz/developer-documentation/citrea-usd-ctusd",
     module: "citrea-ctusd",
-    doublecounted: true
+    // ctUSD is the foundational stablecoin of the Citrea ecosystem, so it is
+    // counted on Citrea. To avoid double-counting its M0 backing, an equivalent
+    // amount is subtracted from M's circulating on Ethereum via the M adapter's
+    // `unreleased` function.
   },
   {
     id: "351",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted ctUSD supply reporting to avoid double-counting, improving the accuracy of pegged asset balances.
  * Circulating supply figures now better reflect ctUSD backing across chains, reducing inconsistencies in displayed totals.

* **Documentation**
  * Added a clarifying note explaining how ctUSD is accounted for in supply calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->