### PR TITLE
Add Tori trUSD synthetic dollar

### DIFF
--- a/src/adapters/peggedAssets/tori-usd/index.ts
+++ b/src/adapters/peggedAssets/tori-usd/index.ts
@@ -1,0 +1,9 @@
+const chainContracts = {
+  ethereum: {
+    issued: ["0xd0580192E98eA6CEB9c7b6191Ed2E27560911697"],
+  },
+};
+
+import { addChainExports } from "../helper/getSupply";
+const adapter = addChainExports(chainContracts);
+export default adapter;

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8297,4 +8297,27 @@ export default [
     wiki: "https://saturncredit.gitbook.io/saturn-docs/solution/usdat-overview",
     module: "saturn-dollar",
   },
+  {
+    id: "401",
+    name: "Tori trUSD",
+    address: "0xd0580192E98eA6CEB9c7b6191Ed2E27560911697",
+    symbol: "trUSD",
+    url: "https://tori.finance",
+    description:
+      "trUSD is a crypto-native synthetic dollar issued by Tori Finance that provides an embedded, performance-based yield and targets price stability through delta-neutral, market-neutral trading positions managed by a regulated institutional asset manager.",
+    mintRedeemDescription:
+      "Whitelisted users deposit eligible collateral with Tori Finance to mint trUSD, and redeem trUSD for collateral. Stability is targeted through delta-neutral hedging of the backing positions across trading venues.",
+    onCoinGecko: false,
+    gecko_id: null,
+    cmcId: null,
+    pegType: "peggedUSD",
+    pegMechanism: "crypto-backed",
+    priceSource: "defillama",
+    auditLinks: [
+      "https://github.com/sherlock-protocol/sherlock-reports/blob/main/audits/2026.02.10%20-%20Final%20-%20Tori%20Finance%20Collaborative%20Audit%20Report%201770734349.pdf",
+    ],
+    twitter: "https://x.com/tori_finance",
+    wiki: "https://docs.tori.finance",
+    module: "tori-usd",
+  },
 ] as PeggedAsset[];


### PR DESCRIPTION
Adds trUSD, a crypto-native synthetic dollar issued by Tori Finance on Ethereum mainnet. Circulating supply is read on-chain from erc20:totalSupply via the addChainExports helper, the same way USDe is read for its Ethereum issuance.

- Name: Tori trUSD
- Website: https://tori.finance
- Chain: Ethereum
- Token: 0xd0580192E98eA6CEB9c7b6191Ed2E27560911697 (trUSD, 18 decimals)
- pegType: peggedUSD
- pegMechanism: crypto-backed
- priceSource: defillama
- Wiki: https://docs.tori.finance
- Twitter: https://x.com/tori_finance
- Audit: Sherlock (full report URL in the registry entry)

Short description: trUSD is a crypto-native synthetic dollar issued by Tori Finance that provides an embedded, performance-based yield when staked, and targets price stability through delta-neutral trading positions.

Notes:
- Complements the existing "Tori Finance" TVL protocol (slug tori-finance, marked doublecounted), so trUSD is reported in the stablecoins dataset to avoid double-counting in TVL.
- gecko_id and cmcId left null since trUSD is not yet listed; module "tori-usd" points the loader at the new adapter folder. Logo will be submitted via the DefiLlama Discord per the README.

Tested locally: the peggedAssets test for tori-usd reports about $45.89M circulating from on-chain totalSupply.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Tori Finance `trUSD` pegged asset.
  * Included its on-chain address, metadata, pricing details, and reference links in the asset list.
  * Added a new chain configuration so the asset can be recognized and exported by the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->