### PR TITLE
fix: mark collapsed stablecoins USN, R, and ZeUSD deadFrom

### DIFF
--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -1169,6 +1169,7 @@ export default [
     pegMechanism: "algorithmic",
     priceSource: "defillama",
     auditLinks: null,
+    deadFrom: "2022-10-24",
     twitter: "https://twitter.com/DcntrlBank",
     wiki: "https://wiki.defillama.com/wiki/USN",
   },
@@ -2479,6 +2480,7 @@ export default [
     auditLinks: [
       "https://github.com/trailofbits/publications/blob/master/reviews/2023-04-tempus-raft-securityreview.pdf",
     ],
+    deadFrom: "2023-11-10",
     twitter: "https://twitter.com/raft_fi",
     wiki: null,
     deadUrl: true,
@@ -4815,6 +4817,7 @@ export default [
     pegMechanism: "fiat-backed",
     auditLinks: ["https://docs.zoth.io/zoth/resources/audits"],
     priceSource: "defillama",
+    deadFrom: "2025-03-19",
     twitter: "https://x.com/zothdotio",
     wiki: "https://docs.zoth.io/zoth/products/zeusd-an-omni-chain-and-composable-stable-token"
   },


### PR DESCRIPTION
This PR marks three collapsed/wound-down stablecoins (USN, R, and Zoth ZeUSD) as dead in the peggedData manifest using the `deadFrom` property. This stops further data collection, preventing the obsolete/frozen supplies from inflating global stablecoin circulating totals.

1. **USN (id: 54)**:
   - The original algorithmic stablecoin of NEAR Protocol.
   - On October 24, 2022, the Decentralized Bank officially announced the wind-down of USN.
   - Depegged completely, yet still counted at its frozen $1.41M supply and $1.00 face-value in production.
   - Added `deadFrom: "2022-10-24"`.

2. **R (id: 115)**:
   - The overcollateralized stablecoin of Raft.
   - Suffered a major $3.3 million exploit and depegged completely on November 10, 2023.
   - Raft officially paused minting and announced a wind-down on November 14, 2023.
   - Still counted at its frozen $10.7M supply and $1.00 face-value in production.
   - Added `deadFrom: "2023-11-10"`.

3. **Zoth ZeUSD (id: 225)**:
   - The RWA-backed stablecoin of Zoth.
   - Suffered a major $8.4 million admin-key drain/exploit in March 2025, with RWA backing drained.
   - Circulating supply has been completely frozen on-chain since, yet still counted at its frozen $27.6M supply and $1.00 face-value in production.
   - Added `deadFrom: "2025-03-19"`.

By marking these three permanently collapsed stablecoins as dead, we remove a total of **~$39.7M** in phantom/stale stablecoin supply from the global circulating metrics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated pegged asset data to better reflect deprecation timelines for several assets.
  * Users may now see more accurate status information for USN, R, and Zoth ZeUSD.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->