### PR TITLE
Add USDe on Monad

### DIFF
--- a/src/adapters/peggedAssets/ethena-usde/layerzeroConfig.ts
+++ b/src/adapters/peggedAssets/ethena-usde/layerzeroConfig.ts
@@ -30,6 +30,7 @@ const layerzeroConfig: LayerZeroConfig = {
     { chain: "swellchain", address: "0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34", decimals: 18 }, // NativeOFT USDe (lz:swell)
     { chain: "xlayer", address: "0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34", decimals: 18 }, // NativeOFT USDe (lz:xlayer)
     { chain: "zircuit", address: "0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34", decimals: 18 }, // NativeOFT USDe (lz:zircuit)
+    { chain: "monad", address: "0x5d3a1Ff2b6BAb83b63cd9AD0787074081a52ef34", decimals: 18 }, // NativeOFT USDe (lz:monad)
   ],
 };
 


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.


---
(fill in below form only for new listings)

##### Name (to be shown on DefiLlama): 


##### Website Link:


##### Logo (High resolution, will be shown with rounded borders):


##### Chain:


##### Coingecko ID (leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description:

##### mintRedeemDescription:


##### Token address and ticker:


##### pegType:

##### pegMechanism:

##### priceSource:

##### wiki:

##### Twitter Link:


##### List of audit links if any:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Monad network in the Ethena USDe token configuration, including its token contract address and 18-decimal format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->