### PR TITLE
Update Tori trUSD: add CoinGecko id (tori-trusd)

### DIFF
--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8307,11 +8307,11 @@ export default [
     symbol: "trUSD",
     url: "https://tori.finance",
     description:
-      "trUSD is a crypto-native synthetic dollar issued by Tori Finance that provides an embedded, performance-based yield and targets price stability through delta-neutral, market-neutral trading positions managed by a regulated institutional asset manager.",
+      "trUSD is a crypto-native synthetic dollar issued by Tori Finance that provides an embedded, performance-based yield and targets price stability through delta-neutral trading positions.",
     mintRedeemDescription:
       "Whitelisted users deposit eligible collateral with Tori Finance to mint trUSD, and redeem trUSD for collateral. Stability is targeted through delta-neutral hedging of the backing positions across trading venues.",
-    onCoinGecko: false,
-    gecko_id: null,
+    onCoinGecko: true,
+    gecko_id: "tori-trusd",
     cmcId: null,
     pegType: "peggedUSD",
     pegMechanism: "crypto-backed",


### PR DESCRIPTION
Follow-up to #824 (merged), which added trUSD to the stablecoins dataset.

trUSD is now listed on CoinGecko (id: tori-trusd), so this updates the existing entry:
- Sets onCoinGecko: true and gecko_id: "tori-trusd".
- priceSource stays "defillama" for now (the CoinGecko listing has no live market price yet; it can move to coingecko once a market exists).
- Tightens the description to "delta-neutral trading positions" (removes redundant wording).

No other fields change. id 401, module tori-usd, pegType peggedUSD, pegMechanism crypto-backed unchanged. Circulating continues to read on-chain from erc20:totalSupply (currently about $49M).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the `Tori trUSD` asset description for clearer wording around how its backing positions are hedged.
  * Enabled CoinGecko tracking for `Tori trUSD` and added its CoinGecko identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->