### PR TITLE
Add Monetrix USDM stablecoin adapter

### DIFF
--- a/src/adapters/peggedAssets/monetrix-usdm/index.ts
+++ b/src/adapters/peggedAssets/monetrix-usdm/index.ts
@@ -1,0 +1,17 @@
+const chainContracts = {
+  hyperliquid: {
+    issued: ["0xE2d2959f89B6389DeB624bF076Fe7D9E5401f377"],
+  },
+};
+
+import { addChainExports } from "../helper/getSupply";
+
+// USDM is a delta-neutral, yield-bearing synthetic dollar issued on HyperEVM
+// (6 decimals). It is minted 1:1 against USDC, so the circulating supply equals
+// USDM totalSupply; there is no unreleased/reserve tranche to exclude.
+const adapter = addChainExports(chainContracts, undefined, {
+  pegType: "peggedUSD",
+  decimals: 6,
+});
+
+export default adapter;

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8366,4 +8366,25 @@ export default [
     wiki: "https://docs.moneyprotocol.co/docs/intro",
     module: "money-protocol",
   },
+  {
+    id: "404",
+    name: "Monetrix USDM",
+    address: "hyperliquid:0xE2d2959f89B6389DeB624bF076Fe7D9E5401f377",
+    symbol: "USDM",
+    url: "https://www.monetrix.xyz/",
+    description:
+      "USDM is a delta-neutral, yield-bearing synthetic dollar on HyperEVM. It is backed by USDC collateral deployed into delta-neutral basis-trading positions (funding payments, HLP and borrow-lend yield) on Hyperliquid Core, and mints/redeems 1:1 against USDC.",
+    mintRedeemDescription:
+      "Users mint USDM 1:1 by depositing USDC, which the protocol deploys into delta-neutral positions on Hyperliquid Core. USDM can be staked for sUSDM to earn the strategy yield, and is redeemed back to USDC 1:1.",
+    onCoinGecko: "false",
+    gecko_id: "monetrix-usdm", // placeholder: USDM is not yet listed on CoinGecko
+    cmcId: null,
+    pegType: "peggedUSD",
+    pegMechanism: "crypto-backed",
+    priceSource: null,
+    auditLinks: null,
+    twitter: null,
+    wiki: null,
+    module: "monetrix-usdm",
+  },
 ] as PeggedAsset[];


### PR DESCRIPTION
Adds Monetrix USDM to the stablecoins section.

**What it is:** USDM is a delta-neutral, yield-bearing synthetic dollar on HyperEVM (HyperEVM / Hyperliquid L1), minted 1:1 against USDC and backed by delta-neutral basis-trading positions (funding payments, HLP and borrow-lend yield) on Hyperliquid Core. Same category as Ethena sUSDe.

**Adapter:** circulating supply = `USDM.totalSupply()` on HyperEVM (6 decimals); no unreleased/reserve tranche. `pegType: peggedUSD`, `pegMechanism: crypto-backed`.

- Token: `hyperliquid:0xE2d2959f89B6389DeB624bF076Fe7D9E5401f377`
- New folder `src/adapters/peggedAssets/monetrix-usdm/`, registered in `peggedData.ts` (id 404, module `monetrix-usdm`).
- Not yet on CoinGecko, so `gecko_id` is a placeholder and `priceSource: null` (values at the $1 peg).

Local test passes:
```
npx ts-node --transpile-only test.ts monetrix-usdm peggedUSD
Detected stablecoin: monetrix-usdm (id: 404)
hyperliquid  minted 2.49 M  circulating 2.49 M  unreleased 0
```

Will submit website/ticker/icon via Discord after the PR, per the README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Monetriz USDM as a new pegged USD asset.
  * Included Hyperliquid token details and asset metadata so it can appear in supported asset listings.
  * Added mint/redeem and peg information for the new asset, along with its basic project details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->