### PR TITLE
Fix Liquity BOLD (id 269) address to point to v2 token

### DIFF
--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -5687,7 +5687,7 @@ export default [
   {
     id: "269",
     name: "Liquity BOLD",
-    address: "0xb01dd87b29d187f3e3a4bf6cdaebfb97f3d9ab98",
+    address: "0x6440f144b7e50D6a8439336510312d2F54beB01D",
     symbol: "BOLD",
     url: "https://www.liquity.org/bold",
     description:


### PR DESCRIPTION
## Summary
Fix Liquity BOLD (id 269) address to point to the v2 token `0x6440f144b7e50D6a8439336510312d2F54beB01D` instead of the legacy v1 contract, matching its adapter and CoinGecko.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the contract address for the Liquity BOLD pegged asset to the correct new address. All other asset details remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->