### PR TITLE
Add Monad export to celo-euro adapter to count bridged EURm

### DIFF
--- a/src/adapters/peggedAssets/celo-euro/index.ts
+++ b/src/adapters/peggedAssets/celo-euro/index.ts
@@ -86,6 +86,16 @@ const adapter: PeggedIssuanceAdapter = {
       "peggedEUR"
     ),
   },
+  monad: {
+    celo: bridgedSupply(
+      "monad",
+      18,
+      chainContracts.monad.bridgedFromCelo,
+      undefined,
+      "Celo",
+      "peggedEUR"
+    ),
+  },
 };
 
 export default adapter;


### PR DESCRIPTION
## Summary 
Add the missing Monad entry to the celo-euro adapter's exports so the ~296k EURm bridged to Monad (added in PR #820 but never read by the hand-built adapter object) is now counted.