### PR TITLE
Add Base and BSC deployments to apxusd adapter

### DIFF
--- a/src/adapters/peggedAssets/apxusd/index.ts
+++ b/src/adapters/peggedAssets/apxusd/index.ts
@@ -2,6 +2,12 @@ const chainContracts = {
   ethereum: {
     issued: ["0x98A878b1Cd98131B271883B390f68D2c90674665"],
   },
+  base: {
+    issued: ["0xd993935e13851dd7517af10687ec7e5022127228"],
+  },
+  bsc: {
+    issued: ["0x6b3788fd6604bbf03c5378d24e57bb334baad4af"],
+  },
 };
 
 import { addChainExports } from "../helper/getSupply";


### PR DESCRIPTION
## Summary
Add the Base and BSC apxUSD deployments (~11.6M combined, previously uncounted) to the adapter as issued supply.
https://basescan.org/address/0xd993935e13851dd7517af10687ec7e5022127228
https://bscscan.com/address/0x6b3788fd6604bbf03c5378d24e57bb334baad4af

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the APXUSD asset configuration to use the correct Base network issued address.
  * Ensured related chain entries remain present in the asset setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->