### PR TITLE
Add Polymarket USD (pUSD)

### DIFF
--- a/src/adapters/peggedAssets/polymarket-usd/index.ts
+++ b/src/adapters/peggedAssets/polymarket-usd/index.ts
@@ -1,0 +1,9 @@
+const chainContracts = {
+  polygon: {
+    issued: ["0xc011a7e12a19f7b1f670d46f03b03f3342e82dfb"],
+  },
+};
+
+import { addChainExports } from "../helper/getSupply";
+const adapter = addChainExports(chainContracts, undefined, { decimals: 6 });
+export default adapter;

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8389,4 +8389,26 @@ export default [
     module: "monetrix-usdm",
     doublecounted: true,
   },
+  {
+    id: "405",
+    name: "Polymarket USD",
+    address: "polygon:0xc011a7e12a19f7b1f670d46f03b03f3342e82dfb",
+    symbol: "pUSD",
+    url: "https://polymarket.com/",
+    description:
+      "pUSD is Polymarket's USD-pegged settlement coin on Polygon, backed 1:1 by USDC. It is used as the collateral and settlement currency for Polymarket prediction markets.",
+    mintRedeemDescription:
+      "pUSD is minted 1:1 by depositing USDC into Polymarket and is redeemed 1:1 back to USDC when funds are withdrawn.",
+    onCoinGecko: "true",
+    gecko_id: "polymarket-usd",
+    cmcId: null,
+    pegType: "peggedUSD",
+    pegMechanism: "crypto-backed",
+    priceSource: "defillama",
+    auditLinks: null,
+    twitter: "https://x.com/Polymarket",
+    wiki: null,
+    module: "polymarket-usd",
+    doublecounted: true,
+  },
 ] as PeggedAsset[];


### PR DESCRIPTION
## Summary

List Polymarket USD (pUSD), Polymarket's USDC-backed settlement coin on Polygon, with a new adapter and pegged-asset entry flagged as doublecounted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Polymarket USD (pUSD) as a new pegged asset.
  * Included Polygon contract details, price/peg metadata, and CoinGecko mapping for better asset tracking.
  * Added a new adapter so pUSD can be recognized and processed by the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->