### PR TITLE
Add USDA (AP Web3)

### DIFF
--- a/src/adapters/peggedAssets/usda-3/index.ts
+++ b/src/adapters/peggedAssets/usda-3/index.ts
@@ -1,0 +1,9 @@
+const chainContracts = {
+  bsc: {
+    issued: ["0x17eafd08994305d8ace37efb82f1523177ec70ee"],
+  },
+};
+
+import { addChainExports } from "../helper/getSupply";
+const adapter = addChainExports(chainContracts);
+export default adapter;

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8389,4 +8389,25 @@ export default [
     module: "monetrix-usdm",
     doublecounted: true,
   },
+  {
+    id: "407",
+    name: "USDA",
+    address: "bsc:0x17eafd08994305d8ace37efb82f1523177ec70ee",
+    symbol: "USDA",
+    url: "https://alphapartner.vip/",
+    description:
+      "USDA is a compliant, cross-chain stablecoin issued by the AP Web3 ecosystem, anchored 1:1 to the US Dollar and designed as secure digital payment and asset settlement infrastructure for global users.",
+    mintRedeemDescription:
+      "USDA is minted when users deposit USD with the issuer, and it can be redeemed 1:1 for the USD held in its reserves.",
+    onCoinGecko: "true",
+    gecko_id: "usda-3",
+    cmcId: null,
+    pegType: "peggedUSD",
+    pegMechanism: "fiat-backed",
+    priceSource: "coingecko",
+    auditLinks: null,
+    twitter: "https://x.com/APalphalabs",
+    wiki: null,
+    module: "usda-3",
+  },
 ] as PeggedAsset[];


### PR DESCRIPTION
## Summary
List USDA, AP Web3's fiat-backed USD stablecoin on BSC (~87M supply), with a new adapter and pegged-asset entry.
https://bscscan.com/address/0x17eafd08994305d8ace37efb82f1523177ec70ee
https://x.com/APalphalabs
https://alphapartner.vip/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new pegged asset, USDA, including its asset details and peg information.
  * Enabled adapter coverage for USDA on BSC so the asset can be recognized and tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->