### PR TITLE
add polymarket

### DIFF
--- a/src/adapters/peggedAssets/polymarket-usd/index.ts
+++ b/src/adapters/peggedAssets/polymarket-usd/index.ts
@@ -1,0 +1,9 @@
+const chainContracts = {
+  polygon: {
+    issued: ["0xc011a7e12a19f7b1f670d46f03b03f3342e82dfb"],
+  },
+};
+
+import { addChainExports } from "../helper/getSupply";
+const adapter = addChainExports(chainContracts, undefined, { decimals: 6 });
+export default adapter;

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8390,7 +8390,7 @@ export default [
     doublecounted: true,
   },
   {
-    id: "407",
+    id: "405",
     name: "USDA",
     address: "bsc:0x17eafd08994305d8ace37efb82f1523177ec70ee",
     symbol: "USDA",
@@ -8409,5 +8409,27 @@ export default [
     twitter: "https://x.com/APalphalabs",
     wiki: null,
     module: "usda-3",
+  },
+  {
+    id: "406",
+    name: "Polymarket USD",
+    address: "polygon:0xc011a7e12a19f7b1f670d46f03b03f3342e82dfb",
+    symbol: "pUSD",
+    url: "https://polymarket.com/",
+    description:
+      "pUSD is Polymarket's USD-pegged settlement coin on Polygon, backed 1:1 by USDC. It is used as the collateral and settlement currency for Polymarket prediction markets.",
+    mintRedeemDescription:
+      "pUSD is minted 1:1 by depositing USDC into Polymarket and is redeemed 1:1 back to USDC when funds are withdrawn.",
+    onCoinGecko: "true",
+    gecko_id: "polymarket-usd",
+    cmcId: null,
+    pegType: "peggedUSD",
+    pegMechanism: "crypto-backed",
+    priceSource: "defillama",
+    auditLinks: null,
+    twitter: "https://x.com/Polymarket",
+    wiki: null,
+    module: "polymarket-usd",
+    doublecounted: true,
   },
 ] as PeggedAsset[];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for **Polymarket USD** as a new pegged asset, including its market data, pricing details, and 6-decimal display handling.
  * Updated the pegged asset list with a revised identifier for **USDA**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->