### PR TITLE
Add MYRT (MYR Stablecoin)

### DIFF
--- a/src/adapters/peggedAssets/myr-stablecoin/index.ts
+++ b/src/adapters/peggedAssets/myr-stablecoin/index.ts
@@ -1,0 +1,12 @@
+import { addChainExports } from "../helper/getSupply";
+
+const chainContracts = {
+  ethereum: {
+    issued: ["0x3Fc98a885E99420d0ce43Bcb81bF21A4e3F45E5f"],
+  },
+};
+
+export default addChainExports(chainContracts, undefined, {
+  pegType: "peggedMYR",
+  decimals: 6,
+});

--- a/src/adapters/peggedAssets/peggedAsset.type.ts
+++ b/src/adapters/peggedAssets/peggedAsset.type.ts
@@ -23,6 +23,7 @@ export type PeggedAssetType =
   | "peggedRUB"
   | "peggedPHP"
   | "peggedMXN"
+  | "peggedMYR"
   | "peggedAUD"
   | "peggedKES"
   | "peggedZAR"

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8432,4 +8432,26 @@ export default [
     module: "polymarket-usd",
     doublecounted: true,
   },
+  {
+    id: "407",
+    name: "MYR Stablecoin",
+    address: "0x3Fc98a885E99420d0ce43Bcb81bF21A4e3F45E5f",
+    symbol: "MYRT",
+    url: "https://myrt.money/",
+    description:
+      "MYRT is an ERC-20 stablecoin for Malaysian ringgit-denominated value. MYRT is pegged 1:1 to the Malaysian ringgit and backed by ringgit reserves.",
+    mintRedeemDescription:
+      "MYRT is issued 1:1 against Malaysian ringgit reserves. All issued MYRT is treated as circulating supply, with no treasury, team, reserve, unreleased, or project-owned token balances to subtract.",
+    onCoinGecko: "false",
+    gecko_id: "myr-stablecoin",
+    cmcId: null,
+    pegType: "peggedMYR",
+    pegMechanism: "fiat-backed",
+    priceSource: "defillama",
+    auditLinks: [
+      "https://github.com/myrt-money/myrt-smart-contract/blob/main/docs/AUDIT_NOTICE.md",
+    ],
+    twitter: "https://x.com/MYRT_money",
+    wiki: "https://github.com/myrt-money/myrt-smart-contract",
+  },
 ] as PeggedAsset[];

--- a/src/peggedData/types.ts
+++ b/src/peggedData/types.ts
@@ -6,6 +6,7 @@ type PegType =
   | "peggedJPY" //japan
   | "peggedCNY" //china
   | "peggedMXN" //mexican peso
+  | "peggedMYR" //Malaysian ringgit
   | "peggedUAH" //ukraine
   | "peggedARS" //ARGENTINE
   | "peggedGBP" //GB


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

(fill in below form only for new listings)

##### Name (to be shown on DefiLlama): 
MYR Stablecoin

##### Website Link:
https://myrt.money/

##### Logo (High resolution, will be shown with rounded borders):
https://myrt.money/logos/myrt/android-icon-512x512.png

##### Chain:
Ethereum

##### Coingecko ID (leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description:
MYRT is an Ethereum ERC-20 stablecoin backed 1:1 by Malaysian Ringgit reserves for Malaysian payments, payroll, merchant settlement, and on-chain settlement.

##### mintRedeemDescription:
MYRT is issued 1:1 against Malaysian Ringgit reserves. Issued MYRT represents client/user-owned balances, including balances held under custodian wallets on behalf of users. There are no treasury, team, reserve, unreleased, or project-owned balances to subtract, so totalSupply is treated as circulating supply.

##### Token address and ticker:
0x3Fc98a885E99420d0ce43Bcb81bF21A4e3F45E5f - MYRT

##### pegType:
peggedMYR

##### pegMechanism:
fiat-backed

##### priceSource:
defillama

Price note: MYRT should follow the Malaysian Ringgit rate. 1 MYRT = 1 MYR.

##### wiki:
https://github.com/myrt-money/myrt-smart-contract

##### Twitter Link:
https://x.com/MYRT_money

##### List of audit links if any:
https://github.com/myrt-money/myrt-smart-contract/blob/main/docs/AUDIT_NOTICE.md
https://github.com/paxosglobal/paxos-token-contracts/tree/v2.1.0/audits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new MYR-pegged stablecoin entry with token details and related metadata.
  * Expanded pegged asset support to recognize a new MYR-based peg type.
  * Registered a new chain export so the asset can be surfaced correctly across supported networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->