### PR TITLE
Add Freedom Dollar (fUSD) on Zano

### DIFF
--- a/src/adapters/peggedAssets/freedom-dollar/index.ts
+++ b/src/adapters/peggedAssets/freedom-dollar/index.ts
@@ -1,0 +1,29 @@
+const axios = require("axios");
+import { sumSingleBalance } from "../helper/generalUtil";
+import { Balances, PeggedIssuanceAdapter } from "../peggedAsset.type";
+
+const assetId =
+  "86143388bd056a8f0bab669f78f14873fac8e2dd8d57898cdb725a2d5e2e4f8f";
+
+async function zanoMinted(): Promise<Balances> {
+  const balances = {} as Balances;
+  const res = await axios.get(
+    `https://explorer.zano.org/api/get_asset_details/${assetId}`
+  );
+  const asset = res.data?.asset;
+  console.log('asset', asset)
+  if (!asset) {
+    throw new Error(`Zano API returned no asset details for ${assetId}`);
+  }
+  const supply = Number(asset.current_supply) / 10 ** Number(asset.decimal_point);
+  sumSingleBalance(balances, "peggedUSD", supply, "issued", false);
+  return balances;
+}
+
+const adapter: PeggedIssuanceAdapter = {
+  zano: {
+    minted: zanoMinted,
+  },
+};
+
+export default adapter;

--- a/src/adapters/peggedAssets/helper/chains.json
+++ b/src/adapters/peggedAssets/helper/chains.json
@@ -251,6 +251,7 @@
   "xdc",
   "xlayer",
   "xsat",
+  "zano",
   "zilliqa",
   "zircuit",
   "zkfair",

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8432,4 +8432,25 @@ export default [
     module: "polymarket-usd",
     doublecounted: true,
   },
+  {
+    id: "415",
+    name: "Freedom Dollar",
+    address: "zano:86143388bd056a8f0bab669f78f14873fac8e2dd8d57898cdb725a2d5e2e4f8f",
+    symbol: "fUSD",
+    url: "https://www.freedomdollar.com/",
+    description:
+      "Freedom Dollar (fUSD) is an over-collateralized, algorithmic stable asset issued on the Zano privacy blockchain. Each fUSD targets one U.S. dollar of purchasing power and is backed by a public reserve of ZANO that initially exceeds the liability by roughly a factor of ten. Collateral is held in transparent on-chain addresses and is continuously staked, so its yield compounds the buffer automatically. Because Zano uses ring signatures and stealth addresses, fUSD transfers inherit native Zano-level privacy while remaining censorship-resistant, with no admin freeze key or custodial bank account.",
+    mintRedeemDescription:
+      "fUSD is minted against an over-collateralized public reserve of staked ZANO that targets roughly ten times the fUSD liability, and redeemed against that reserve to maintain the 1:1 U.S. dollar target. Anyone can help maintain the peg by running an open-source market-making node.",
+    onCoinGecko: "true",
+    gecko_id: "freedom-dollar",
+    cmcId: null,
+    pegType: "peggedUSD",
+    pegMechanism: "crypto-backed",
+    priceSource: "coingecko",
+    auditLinks: null,
+    twitter: "https://x.com/freedomdollar5",
+    wiki: null,
+    module: "freedom-dollar",
+  },
 ] as PeggedAsset[];


### PR DESCRIPTION
## Summary
List Freedom Dollar (fUSD), an over-collateralized (ZANO-backed) stablecoin on the Zano privacy blockchain.
https://explorer.zano.org/assets
https://www.freedomdollar.com/en
https://x.com/freedomdollar5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Freedom Dollar (fUSD) as a new pegged asset.
  * Introduced support for the Zano chain in pegged asset tracking.
  * Enabled reporting of newly issued fUSD balances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->