### PR TITLE
Add Stellar supply tracking for Valtorum USD

### DIFF
--- a/src/adapters/peggedAssets/valtorum-usdv/index.ts
+++ b/src/adapters/peggedAssets/valtorum-usdv/index.ts
@@ -38,8 +38,12 @@ async function stellarMinted() {
     )
   );
 
-  const supply = parseFloat(res.data._embedded?.records?.[0]?.amount ?? "0");
-
+const record = res.data._embedded?.records?.[0];
+const supply = parseFloat(record?.balances?.authorized ?? "0")
+  + parseFloat(record?.balances?.authorized_to_maintain_liabilities ?? "0")
+  + parseFloat(record?.claimable_balances_amount ?? "0")
+  + parseFloat(record?.liquidity_pools_amount ?? "0")
+  + parseFloat(record?.contracts_amount ?? "0");
   sumSingleBalance(balances, "peggedUSD", supply, "issued", false);
   return balances;
 }

--- a/src/adapters/peggedAssets/valtorum-usdv/index.ts
+++ b/src/adapters/peggedAssets/valtorum-usdv/index.ts
@@ -5,9 +5,11 @@ import { sumSingleBalance } from "../helper/generalUtil";
 import { Balances, PeggedIssuanceAdapter } from "../peggedAsset.type";
 
 const NODE_URL = "https://xrplcluster.com";
+const STELLAR_HORIZON = "https://horizon.stellar.org";
 
 const USDV_ISSUER = "rfffsukWALJB1PXYk7H8xkR6UJUDT8nMJE";
 const USDV_CURRENCY = "5553445600000000000000000000000000000000";
+const STELLAR_USDV_ISSUER = "GBLAJOKBIIT7P32BJQFCSRJVOE2SXHI4D5ZGLFJ4DLMFJXI2NN6R37G5";
 
 async function minted() {
   const balances = {} as Balances;
@@ -27,10 +29,27 @@ async function minted() {
   sumSingleBalance(balances, "peggedUSD", supply, "issued", false);
   return balances;
 }
+async function stellarMinted() {
+  const balances = {} as Balances;
 
+  const res = await retry(async (_bail: any) =>
+    axios.get(
+      `${STELLAR_HORIZON}/assets?asset_code=USDV&asset_issuer=${STELLAR_USDV_ISSUER}`
+    )
+  );
+
+  const supply = parseFloat(res.data._embedded?.records?.[0]?.amount ?? "0");
+
+  sumSingleBalance(balances, "peggedUSD", supply, "issued", false);
+  return balances;
+}
 const adapter: PeggedIssuanceAdapter = {
   ripple: {
     minted,
+    unreleased: async () => ({}),
+  },
+  stellar: {
+    minted: stellarMinted,
     unreleased: async () => ({}),
   },
 };


### PR DESCRIPTION
Adds Stellar supply tracking to the existing Valtorum USD adapter.

Stellar asset:
USDV:GBLAJOKBIIT7P32BJQFCSRJVOE2SXHI4D5ZGLFJ4DLMFJXI2NN6R37G5

Supply source:
Stellar Horizon /assets endpoint

This keeps the existing XRPL tracking and adds Stellar as an additional chain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Stellar support for USDV supply tracking.
  * USDV balances can now be reported from Stellar alongside the existing Ripple support.

* **Bug Fixes**
  * Improved handling of missing or incomplete supply data by defaulting values to zero, helping prevent inaccurate totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->