### PR TITLE
fix: FX fallback price broken for peggedREAL (BRTH shows mcap 0)

### DIFF
--- a/api2/cron-task/getStableCoins.ts
+++ b/api2/cron-task/getStableCoins.ts
@@ -1,6 +1,7 @@
 import * as sdk from "@defillama/sdk";
 import peggedAssets from "../../src/peggedData/peggedData";
 import { secondsInDay, secondsInWeek } from "../../src/utils/date";
+import { fxFallbackPrice } from "../../src/utils/fxRates";
 import {
     addToChains,
     nonChains,
@@ -59,7 +60,8 @@ function craftProtocolsResponse(
         lastSK - secondsInDay * 30,
         secondsInDay // temporary, update later
       );
-      const fallbackPrice = pegType === "peggedUSD" ? 1 : 0;
+      // assets without a market price fall back to their peg's fiat FX rate, same as charts and dominance
+      const fallbackPrice = fxFallbackPrice(cache.fxRateMap?.latest ?? cache.rates?.rates, pegType);
       const currentPrice = prices[pegged.gecko_id] || null;
       const price = currentPrice ? currentPrice : fallbackPrice;
       const chainCirculating = {} as {

--- a/api2/cron-task/getStablecoinChains.ts
+++ b/api2/cron-task/getStablecoinChains.ts
@@ -1,5 +1,6 @@
 import * as sdk from "@defillama/sdk";
 import peggedAssets from "../../src/peggedData/peggedData";
+import { fxFallbackPrice } from "../../src/utils/fxRates";
 import { nonChains, normalizeChain } from "../../src/utils/normalizeChain";
 import { cache } from "../cache";
 type balance = { [token: string]: number };
@@ -15,7 +16,8 @@ export function craftStablecoinChainsResponse() {
       if (lastBalances === undefined) {
         return;
       }
-      const fallbackPrice = pegType === "peggedUSD" ? 1 : 0; // must be updated with each new pegType added
+      // assets without a market price fall back to their peg's fiat FX rate, same as charts and dominance
+      const fallbackPrice = fxFallbackPrice(cache.fxRateMap?.latest ?? cache.rates?.rates, pegType);
       const currentPrice = prices[pegged.gecko_id] || null;
       const price = currentPrice ? currentPrice : fallbackPrice;
       const processedNormalizedChains = new Set<string>();

--- a/api2/cron-task/storeCharts.ts
+++ b/api2/cron-task/storeCharts.ts
@@ -5,7 +5,7 @@ import { getClosestDayStartTimestamp, secondsInDay, secondsInHour, } from "../..
 import * as sdk from "@defillama/sdk";
 import { normalizeChain } from "../../src/utils/normalizeChain";
 import { getHistoricalValues } from "../../src/utils/shared/dynamodb";
-import { buildFxRateMap, lookupFxRate } from "../../src/utils/fxRates";
+import { buildFxRateMap, lookupFxRate, pegTypeFxTicker } from "../../src/utils/fxRates";
 import { cache } from "../cache";
 import { storeRouteData } from "../file-cache";
 import { chainCacheSlug } from "../utils/cachePath";
@@ -254,7 +254,7 @@ export function craftChartsResponse(
       if (pegType === "peggedVAR") {
         fallbackPrice = 0;
       } else if (pegType !== "peggedUSD" && !historicalPrice) {
-        const ticker = pegType.slice(-3);
+        const ticker = pegTypeFxTicker(pegType);
         const rate = fxRateMap ? lookupFxRate(fxRateMap, ticker, timestamp) : null;
         fallbackPrice = rate ? 1 / rate : 0;
         if (!isFinite(fallbackPrice)) fallbackPrice = 0;

--- a/api2/routes/getChainDominance.ts
+++ b/api2/routes/getChainDominance.ts
@@ -1,5 +1,6 @@
 import peggedAssets from "../../src/peggedData/peggedData";
 import { getTimestampAtStartOfDay } from "../../src/utils/date";
+import { pegTypeFxTicker } from "../../src/utils/fxRates";
 import { normalizeChain } from "../../src/utils/normalizeChain";
 import { cache } from "../cache";
 
@@ -65,9 +66,9 @@ export function craftChainDominanceResponse(chain: string | undefined) {
     if (pegType === "peggedVAR") {
       fallbackPrice = 0;
     } else if (pegType !== "peggedUSD" && !historicalPrice) {
-      const ticker = pegType.slice(-3);
+      const ticker = pegTypeFxTicker(pegType);
       fallbackPrice = 1 / lastRates?.rates?.[ticker];
-      if (typeof fallbackPrice !== "number") {
+      if (!isFinite(fallbackPrice)) {
         fallbackPrice = 0;
       }
     }

--- a/src/utils/fxRates.ts
+++ b/src/utils/fxRates.ts
@@ -10,6 +10,26 @@ export type FxRateMap = {
   latest: Record<string, number>;
 };
 
+// pegTypes follow the "pegged" + ISO 4217 ticker convention, except the ones
+// mapped here (the FX feed keys rates by ISO code, e.g. BRL, not REAL).
+const pegTypeTickerOverrides: Record<string, string> = {
+  peggedREAL: "BRL", // brazilian real
+};
+
+export function pegTypeFxTicker(pegType: string): string {
+  return pegTypeTickerOverrides[pegType] ?? pegType.replace(/^pegged/, "");
+}
+
+// USD price to assume for a pegged asset that has no market price: 1 for USD
+// pegs, the fiat FX rate for other fiat pegs, 0 when the rate is unknown.
+export function fxFallbackPrice(rates: Record<string, number> | undefined, pegType: string): number {
+  if (pegType === "peggedUSD") return 1;
+  if (pegType === "peggedVAR") return 0;
+  const rate = rates?.[pegTypeFxTicker(pegType)];
+  const price = rate ? 1 / rate : 0;
+  return isFinite(price) ? price : 0;
+}
+
 export function buildFxRateMap(rows: FxRateRow[]): FxRateMap | null {
   if (!Array.isArray(rows) || !rows.length) return null;
   const sorted = rows.slice().sort((a, b) => a.date - b.date);


### PR DESCRIPTION
Fixes #743.

## Root cause
BRTH (id 352, `peggedREAL`, Polygon) has no market price: it isn't on CoinGecko and `coins.llama.fi` returns `{"coins":{}}` for it. That part is upstream. But the repo already has an FX-rate fallback for fiat-pegged assets without a market price, and it's broken for BRL pegs in two ways:

1. `storeCharts.ts` and `getChainDominance.ts` derive the FX ticker with `pegType.slice(-3)`. For `peggedREAL` that yields `"EAL"`, but the FX feed (`rates/full`) keys by ISO code (`BRL`), so the lookup always misses and the fallback price becomes 0. Every 3-letter pegType (EUR, GBP, JPY, ...) happens to work by accident; `peggedREAL` is the only 4-letter one and there are 5 such assets.
2. `getStableCoins.ts` and `getStablecoinChains.ts` don't use the FX fallback at all — they hardcode `pegType === "peggedUSD" ? 1 : 0`, so any non-USD asset without a market price gets mcap 0 in the `/stablecoins` and `/stablecoinchains` responses even when the chart code path would have priced it.

(BRZ and cREAL never surfaced this because they have CoinGecko prices.)

## Change
- `src/utils/fxRates.ts`: add `pegTypeFxTicker()` (strips the `pegged` prefix, with an explicit `peggedREAL -> BRL` override) and `fxFallbackPrice()` (1 for USD pegs, `1/fxRate` for fiat pegs, 0 for `peggedVAR`/unknown).
- `storeCharts.ts`, `getChainDominance.ts`: use `pegTypeFxTicker` instead of `slice(-3)`. Also fixed the dominance guard: `typeof (1/undefined) === "number"` is true for NaN, so the old check never caught a missing rate — now `isFinite`.
- `getStableCoins.ts`, `getStablecoinChains.ts`: replace the hardcoded 0 with `fxFallbackPrice` fed from the same cron FX cache, so these responses price fiat pegs consistently with the chart/dominance paths.

## Test
`npm test brth` passes (supply adapter reads 2.97k BRTH live from Polygon).

Fallback exercised against the live FX feed:
```
pegTypeFxTicker(peggedREAL) = BRL
OLD chart lookup (EAL): null
NEW chart lookup (BRL): 5.1451
fxFallbackPrice peggedREAL = 0.1943...   (1/5.1451)
fxFallbackPrice peggedUSD  = 1
fxFallbackPrice peggedVAR  = 0
fxFallbackPrice peggedEUR  = 1.1441...
BRTH mcap with fix ~= $578.61
```

No new type errors in the touched files (the two pre-existing TS2322s in storeCharts/getChainDominance are unchanged on master).