### PR TITLE
Add Elara USD pegged asset

### DIFF
--- a/src/adapters/peggedAssets/elara-usd/index.ts
+++ b/src/adapters/peggedAssets/elara-usd/index.ts
@@ -1,0 +1,10 @@
+import { addChainExports } from "../helper/getSupply";
+
+const chainContracts = {
+  ethereum: {
+    issued: ["0x65Fb0f9b196d524De0C4F3BAF572F0a79eb21194"],
+  },
+};
+
+const adapter = addChainExports(chainContracts);
+export default adapter;

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8432,4 +8432,28 @@ export default [
     module: "polymarket-usd",
     doublecounted: true,
   },
+  {
+    id: "407",
+    name: "Elara USD",
+    address: "0x65Fb0f9b196d524De0C4F3BAF572F0a79eb21194",
+    symbol: "elUSD",
+    url: "https://elara.fi/",
+    description:
+      "Elara USD (elUSD) is a USD-pegged stablecoin issued by Elara on Ethereum. It is minted against supported stablecoin collateral deposited into Elara treasury wallets.",
+    mintRedeemDescription:
+      "Users mint elUSD by depositing supported stablecoin collateral into Elara and redeem elUSD for supported collateral through the Elara Vault.",
+    onCoinGecko: "false",
+    gecko_id: "elara-usd",
+    cmcId: null,
+    pegType: "peggedUSD",
+    pegMechanism: "crypto-backed",
+    priceSource: "defillama",
+    auditLinks: [
+      "https://sherlock-files.ams3.digitaloceanspaces.com/reports/2026.06.14%20-%20Final%20-%20Elara%20Finance%20Collaborative%20Audit%20Report%201781450009.pdf",
+    ],
+    twitter: "https://x.com/Elara_HQ",
+    wiki: "https://docs.elara.fi/",
+    module: "elara-usd",
+    doublecounted: true,
+  },
 ] as PeggedAsset[];

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8439,7 +8439,7 @@ export default [
     symbol: "elUSD",
     url: "https://elara.fi/",
     description:
-      "Elara USD (elUSD) is a USD-pegged stablecoin issued by Elara on Ethereum. It is minted against supported stablecoin collateral deposited into Elara treasury wallets.",
+      "Elara Finance is a treasury management product from the Brila ecosystem that helps treasuries, allocators, institutions, and individuals earn dollar-denominated yield on stablecoins without manually coordinating strategies across DeFi venues.",
     mintRedeemDescription:
       "Users mint elUSD by depositing supported stablecoin collateral into Elara and redeem elUSD for supported collateral through the Elara Vault.",
     onCoinGecko: "false",


### PR DESCRIPTION
## (Needs to be filled only for new listings)

#### Was already requested here https://github.com/DefiLlama/DefiLlama-Adapters/pull/19935

##### Name (to be shown on DefiLlama): 
Elara USD

##### Website Link:
https://elara.fi/

##### Logo (High resolution, will be shown with rounded borders):
https://app.elara.fi/token-elusd.svg

##### Chain:
Ethereum

##### Coingecko ID (leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description:
Elara Finance is a treasury management product from the Brila ecosystem. It gives treasuries, allocators, institutions, and individual investors a way to earn dollar-denominated yield on stablecoins without having to piece together strategies across fragmented DeFi venues themselves.

##### mintRedeemDescription:
Users mint elUSD by depositing supported stablecoin collateral into Elara and redeem elUSD for supported collateral through the Elara Vault.

##### Token address and ticker:
elUSD: `0x65Fb0f9b196d524De0C4F3BAF572F0a79eb21194`

##### pegType:
`peggedUSD`

##### pegMechanism:
`crypto-backed`

##### priceSource:
`defillama`

##### wiki:
https://docs.elara.fi/

##### Twitter Link:
https://x.com/Elara_HQ

##### List of audit links if any:
https://sherlock-files.ams3.digitaloceanspaces.com/reports/2026.06.14%20-%20Final%20-%20Elara%20Finance%20Collaborative%20Audit%20Report%201781450009.pdf

##### Additional implementation notes:
The adapter marks elUSD as `doublecounted: true` because elUSD supply is backed by supported stablecoin collateral already tracked in the Elara TVL adapter.