### PR TITLE
Add Flying Tulip USD (ftUSD) stablecoin adapter

### DIFF
--- a/src/adapters/peggedAssets/flying-tulip-usd/index.ts
+++ b/src/adapters/peggedAssets/flying-tulip-usd/index.ts
@@ -1,0 +1,9 @@
+const chainContracts = {
+  ethereum: {
+    issued: ["0xf7d85ec4e7710f71992752eac2111312e73e9c9c"],
+  },
+};
+
+import { addChainExports } from "../helper/getSupply";
+const adapter = addChainExports(chainContracts);
+export default adapter;

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8729,4 +8729,26 @@ export default [
     wiki: null,
     module: "startale-usd",
   },
+  {
+    id: "421",
+    name: "Flying Tulip USD",
+    address: "0xf7d85ec4e7710f71992752eac2111312e73e9c9c",
+    symbol: "ftUSD",
+    url: "https://flyingtulip.com/",
+    description:
+      "ftUSD is Flying Tulip's dollar-pegged token designed for stability first, usable as a composable on-chain dollar with optional yield when staked as sftUSD.",
+    mintRedeemDescription:
+      "ftUSD is minted by depositing a stablecoin such as USDC or USDT, and redeemed by converting ftUSD back to the input asset at the prevailing rate; holders can stake ftUSD as sftUSD to earn yield.",
+    onCoinGecko: "true",
+    gecko_id: "flying-tulip-usd",
+    cmcId: null,
+    pegType: "peggedUSD",
+    pegMechanism: "crypto-backed",
+    priceSource: "defillama",
+    auditLinks: null,
+    twitter: "https://x.com/flyingtulip_",
+    wiki: null,
+    module: "flying-tulip-usd",
+    doublecounted: true,
+  },
 ] as PeggedAsset[];


### PR DESCRIPTION
## Summary
Add Flying Tulip USD (ftUSD) stablecoin adapter on Ethereum
https://etherscan.io/token/0xf7d85ec4e7710f71992752eac2111312e73e9c9c
https://x.com/flyingtulip_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new pegged asset, Flying Tulip USD (`ftUSD`).
  * Included its metadata and pricing configuration so it can appear in supported asset listings and data views.
  * Enabled chain-specific contract support for Ethereum for this asset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->