### PR TITLE
Add Decentralized Euro (dEURO) stablecoin adapter

### DIFF
--- a/src/adapters/peggedAssets/decentralized-euro/index.ts
+++ b/src/adapters/peggedAssets/decentralized-euro/index.ts
@@ -1,0 +1,21 @@
+const chainContracts = {
+  ethereum: {
+    issued: ["0xba3f535bbcccca2a154b573ca6c5a49baae0a3ea"],
+  },
+  base: {
+    bridgedFromETH: ["0x1b5f7fa46ed0f487f049c42f374ca4827d65a264"],
+  },
+  polygon: {
+    bridgedFromETH: ["0xc2ff25dd99e467d2589b2c26edd270f220f14e47"],
+  },
+  optimism: {
+    bridgedFromETH: ["0x1b5f7fa46ed0f487f049c42f374ca4827d65a264"],
+  },
+  arbitrum: {
+    bridgedFromETH: ["0x5e85faf503621830ca857a5f38b982e0cc57d537"],
+  },
+};
+
+import { addChainExports } from "../helper/getSupply";
+const adapter = addChainExports(chainContracts, undefined, { pegType: "peggedEUR" });
+export default adapter;

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -3098,7 +3098,7 @@ export default [
     symbol: "HYUSD",
     url: "https://linktr.ee/hyusd",
     description:
-      "hyUSD is a secure high yield savings flatcoin with up to 6% rewards outpacing inflation in over 100 countries around the world.",    mintRedeemDescription:
+      "hyUSD is a secure high yield savings flatcoin with up to 6% rewards outpacing inflation in over 100 countries around the world.", mintRedeemDescription:
       "Minting requires a deposit of the defined collateral tokens in equal value amounts to the RToken smart contracts.",
     onCoinGecko: "false",
     gecko_id: null,
@@ -7556,7 +7556,7 @@ export default [
     url: "https://dork.fi",
     description: "WAD is an overcollateralized stablecoin minted through DorkFi, a cross-chain borrow/lend protocol on the Algorand Virtual Machine (AVM). Users deposit collateral assets and borrow WAD at controlled interest rates.",
     mintRedeemDescription: "WAD is minted by depositing accepted collateral (ALGO, USDC, UNIT, VOI) into DorkFi lending pools. WAD can be repaid at any time to reclaim collateral. The protocol uses utilization-based dynamic interest rates.",
-        onCoinGecko: "false",
+    onCoinGecko: "false",
     gecko_id: null,
     cmcId: null,
     pegType: "peggedUSD",
@@ -7806,7 +7806,7 @@ export default [
     description:
       "eSui Dollar (suiUSDe) is a Sui-native synthetic dollar issued in collaboration with Ethena Labs and integrated across Sui DeFi, including DeepBook Margin for margin trading, lending, and leveraged DeFi strategies.",
     mintRedeemDescription:
-    "suiUSDe can be minted by KYCed users depositing USDC into the issuer mint contract, which mints new suiUSDe at a 1:1 ratio, minus any applicable mint fee. The USDC is then managed by the issuer, with part kept as a redemption buffer and the rest used to acquire USDe from Ethena or moved to custody. KYCed users can redeem suiUSDe through the mint contract for USDC, assuming the available USDC buffer is sufficient for the redemption amount.",
+      "suiUSDe can be minted by KYCed users depositing USDC into the issuer mint contract, which mints new suiUSDe at a 1:1 ratio, minus any applicable mint fee. The USDC is then managed by the issuer, with part kept as a redemption buffer and the rest used to acquire USDe from Ethena or moved to custody. KYCed users can redeem suiUSDe through the mint contract for USDC, assuming the available USDC buffer is sufficient for the redemption amount.",
     onCoinGecko: "true",
     gecko_id: "esui-dollar",
     cmcId: null,
@@ -8378,7 +8378,7 @@ export default [
     mintRedeemDescription:
       "Users mint USDM 1:1 by depositing USDC, which the protocol deploys into delta-neutral positions on Hyperliquid Core. USDM can be staked for sUSDM to earn the strategy yield, and is redeemed back to USDC 1:1.",
     onCoinGecko: "true",
-    gecko_id: "monetrix-usd", 
+    gecko_id: "monetrix-usd",
     cmcId: null,
     pegType: "peggedUSD",
     pegMechanism: "crypto-backed",
@@ -8728,5 +8728,26 @@ export default [
     twitter: "https://x.com/StartaleGroup",
     wiki: null,
     module: "startale-usd",
+  },
+  {
+    id: "423",
+    name: "Decentralized Euro",
+    address: "0xba3f535bbcccca2a154b573ca6c5a49baae0a3ea",
+    symbol: "dEURO",
+    url: "https://deuro.com/",
+    description:
+      "dEURO is a collateralized, oracle-free stablecoin that tracks the value of the Euro, minted against crypto collateral and secured by a challenge and auction system.",
+    mintRedeemDescription:
+      "To mint dEURO, open a collateralized position (or clone an existing one); collateral integrity is maintained through a challenge and auction system, and dEURO is redeemed by repaying positions to reclaim the underlying collateral.",
+    onCoinGecko: "true",
+    gecko_id: "decentralized-euro",
+    cmcId: null,
+    pegType: "peggedEUR",
+    pegMechanism: "crypto-backed",
+    priceSource: "defillama",
+    auditLinks: null,
+    twitter: "https://x.com/deuro_com",
+    wiki: null,
+    module: "decentralized-euro",
   },
 ] as PeggedAsset[];

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8736,9 +8736,9 @@ export default [
     symbol: "dEURO",
     url: "https://deuro.com/",
     description:
-      "dEURO is a collateralized, oracle-free stablecoin that tracks the value of the Euro, minted against crypto collateral and secured by a challenge and auction system.",
+      "dEURO is a collateralized, oracle-free stablecoin that tracks the value of the Euro, backed by overcollateralized crypto positions.",
     mintRedeemDescription:
-      "To mint dEURO, open a collateralized position (or clone an existing one); collateral integrity is maintained through a challenge and auction system, and dEURO is redeemed by repaying positions to reclaim the underlying collateral.",
+      "dEURO is minted when users deposit supported crypto collateral (e.g., BTC or ETH) into the protocol's smart contracts and generate new tokens against it based on required overcollateralization ratios, with automated liquidations keeping the system solvent if collateral values fall; it is redeemed by repaying the position to reclaim the underlying collateral.",
     onCoinGecko: "true",
     gecko_id: "decentralized-euro",
     cmcId: null,


### PR DESCRIPTION
## Summary
Add Decentralized Euro (dEURO) stablecoin adapter on Ethereum with bridged supply on Base, Polygon, Optimism, and Arbitrum.
https://x.com/dEURO_com
https://etherscan.io/token/0xba3f535bbcccca2a154b573ca6c5a49baae0a3ea
https://polygonscan.com/token/0xc2ff25dd99e467d2589b2c26edd270f220f14e47#transactions
https://arbiscan.io/token/0x5e85faf503621830ca857a5f38b982e0cc57d537#transactions
https://basescan.org/token/0x1b5f7fa46ed0f487f049c42f374ca4827d65a264
https://optimistic.etherscan.io/token/0x1b5f7fa46ed0f487f049c42f374ca4827d65a264#transactions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new decentralized euro asset, including its listing, metadata, and pricing details.
  * Enabled coverage across multiple chains, including Ethereum and several bridged networks.
* **Updates**
  * Expanded the pegged assets catalog with the new euro-denominated entry.
  * Made minor formatting updates to existing asset definitions without changing their displayed information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->