### PR TITLE
Add bridged USDC denoms on Injective (Noble CCTP/Gateway, Peggy, Wormhole, Axelar)

### DIFF
--- a/src/adapters/peggedAssets/usd-coin/config.ts
+++ b/src/adapters/peggedAssets/usd-coin/config.ts
@@ -540,5 +540,27 @@ export const chainContracts: ChainContracts = {
   },
   injective: {
     issued: ["0xa00C59fF5a080D2b954d0c75e46E22a0c371235a"], // native USDC on Injective EVM
+    // bridged USDC arrives as Cosmos bank denoms (Noble CCTP, Peggy legacy bridge, Wormhole, Axelar)
+    bridgedFromNoble: [
+      "ibc/2CBC2EA121AE42563B08028466F37B600F2D7D4282342DE938283CC3FB2BC00E", // Noble USDC (CCTP)
+      "ibc/7BE71BB68C781453F6BB10114F8E2DF8DC37BA791C502F5389EA10E7BEA68323", // Noble USDC (Gateway)
+    ],
+    bridgedFromETH: [
+      "peggy0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // Peggy (legacy Injective bridge) USDC
+      "factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1q6zlut7gtkzknkk773jecujwsdkgq882akqksk", // Wormhole USDCet
+      "ibc/7E1AF94AD246BE522892751046F0C959B768642E5671CC3742264068D49553C0", // Axelar USDC
+    ],
+    bridgedFromSol: [
+      "factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj12pwnhtv7yat2s30xuf4gdk9qm85v4j3e60dgvu", // Wormhole USDCso
+    ],
+    bridgedFromPolygon: [
+      "factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj19s2r64ghfqq3py7f5dr0ynk8yj0nmngca3yvy3", // Wormhole USDCpoly
+    ],
+    bridgedFromBSC: [
+      "factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1dngqzz6wphf07fkdam7dn55t8t3r6qenewy9zu", // Wormhole USDCbsc
+    ],
+    bridgedFromArbitrum: [
+      "factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1lmcfftadjkt4gt3lcvmz6qn4dhx59dv2m7yv8r", // Wormhole USDCarb
+    ],
   }
 };

--- a/src/adapters/peggedAssets/usd-coin/index.ts
+++ b/src/adapters/peggedAssets/usd-coin/index.ts
@@ -403,25 +403,6 @@ async function aptosBridged() {
   };
 }
 
-async function injectiveBridged() {
-  return async function () {
-    const issuance = await retry(async (_bail: any) =>
-      axios.get("https://injective-nuxt-api.vercel.app/api/tokens")
-    );
-
-    const targetDenom = "ibc/2CBC2EA121AE42563B08028466F37B600F2D7D4282342DE938283CC3FB2BC00E";
-    const targetToken = issuance?.data?.supply?.find(
-      (token: any) => token.denom === targetDenom
-    );
-
-    const circulatingSupply = targetToken ? targetToken.amount / 1e6 : 0;
-    let balances = {};
-    sumSingleBalance(balances, "peggedUSD", circulatingSupply, "issued", false);
-
-    return balances;
-  };
-}
-
 async function flowBridged(address: string, decimals: number) {
   return async function () {
     let balances = {} as Balances;
@@ -964,7 +945,12 @@ const adapter: PeggedIssuanceAdapter = {
   },
   injective: {
     minted: chainMinted("injective", 6), // native USDC on Injective EVM (chainId 1776)
-    noble: cosmosSupply('injective', ['ibc/2CBC2EA121AE42563B08028466F37B600F2D7D4282342DE938283CC3FB2BC00E'], 6, 'noble'),
+    noble: cosmosSupply("injective", chainContracts.injective.bridgedFromNoble, 6, "noble"),
+    ethereum: cosmosSupply("injective", chainContracts.injective.bridgedFromETH, 6, "ethereum"),
+    solana: cosmosSupply("injective", chainContracts.injective.bridgedFromSol, 6, "solana"),
+    polygon: cosmosSupply("injective", chainContracts.injective.bridgedFromPolygon, 6, "polygon"),
+    bsc: cosmosSupply("injective", chainContracts.injective.bridgedFromBSC, 6, "bsc"),
+    arbitrum: cosmosSupply("injective", chainContracts.injective.bridgedFromArbitrum, 6, "arbitrum"),
   },
   noble: {
     minted: circleAPIChainMinted("NOBLE"),


### PR DESCRIPTION
## Summary
Adds the bridged USDC representations on Injective alongside the existing native EVM USDC (`minted`). Previously only native USDC and a single Noble CCTP denom (via a now-removed nuxt-api fetch) were tracked.

Each denom is a Cosmos bank denom, tracked with `cosmosSupply` and attributed to its origin chain:

| Adapter key | Denom | Symbol | Origin |
|---|---|---|---|
| `noble` | ibc/2CBC… (CCTP), ibc/7BE7… (Gateway) | USDCnb, USDCgateway | Noble |
| `ethereum` | peggy0xA0b8…, factory…USDCet, ibc/7E1A… | USDClegacy, USDCet, axlUSDC | Ethereum (Peggy, Wormhole, Axelar) |
| `solana` | factory…USDCso | USDCso | Solana (Wormhole) |
| `polygon` | factory…USDCpoly | USDCpoly | Polygon (Wormhole) |
| `bsc` | factory…USDCbsc | USDCbsc | BSC (Wormhole) |
| `arbitrum` | factory…USDCarb | USDCarb | Arbitrum (Wormhole) |

## Verification
- Every denom confirmed as **6-decimal USDC** against Injective's official token list (`InjectiveLabs/injective-lists`).
- Confirmed **no double-count** with native `minted`: native USDC lives under its own `erc20:0xa00C59…` bank denom, disjoint from all bridged denoms.
- All denoms return live supply via the Injective REST bank module.

## Notes
- `minted` (native EVM USDC) is unchanged and remains required per the README adapter spec.
- Removes the obsolete `injectiveBridged()` nuxt-api helper it supersedes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded USDC tracking on Injective to include bridged supply from multiple networks, including Noble, Ethereum, Solana, Polygon, BSC, and Arbitrum.
  * Added support for additional bridged USDC denomination sources, improving coverage for cross-chain balances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->