### PR TITLE
Fix kUSD (id 402) price chain: Base asset was queried on Ethereum

### DIFF
--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8327,7 +8327,7 @@ export default [
   {
     id: "402",
     name: "Kerne USD",
-    address: "0x5C2EfdF0D8D286959b42308966bc2B97f5680AA3",
+    address: "base:0x5C2EfdF0D8D286959b42308966bc2B97f5680AA3",
     symbol: "kUSD",
     url: "https://kerne.fi",
     description:


### PR DESCRIPTION
### Summary
kUSD (Kerne USD, stablecoin id 402) shows `price: null` on the stablecoins dashboard because of a chain mismatch in the price lookup.

### Root cause
`getTokenAddress` in `src/adapters/peggedAssets/prices/index.ts` prepends `ethereum:` to any bare `0x` address:

```
let id = token.address
if (id) return id.startsWith("0x") ? 'ethereum:' + id : id;
```

The kUSD entry in `peggedData.ts` used a bare Base address, so it was queried on coins.llama.fi as `ethereum:0x5C2EfdF0D8D286959b42308966bc2B97f5680AA3` (a token that does not exist on Ethereum) and never resolved a price. kUSD is Base-native (chain 8453).

### Fix
Prefix the `address` with `base:`, matching the convention already used by other non-Ethereum entries (`avax:`, `celo:`, `arbitrum:`, `optimism:`, `polygon:`, `bsc:`, and others). The lookup now correctly targets `base:0x5C2EfdF0D8D286959b42308966bc2B97f5680AA3`. One line changed in `peggedData.ts`; no adapter or supply logic touched.

### Note on the price value
kUSD is redeemable 1:1 for USDC through an on-chain PSM, so it holds ~$1. If it is not yet resolvable on coins.llama.fi and a hardcode is preferred, it could be pinned to 1 next to the existing `finalRes["m-2"] = 1`. That is entirely your call; this PR only fixes the objective chain mismatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the stored address entry for **Kerne USD (kUSD)** to keep pegged asset data consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->