### PR TITLE
Monetrix: attach Code4rena audit report to USDM stablecoin listing

### DIFF
--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8384,7 +8384,7 @@ export default [
     pegType: "peggedUSD",
     pegMechanism: "crypto-backed",
     priceSource: "defillama",
-    auditLinks: null,
+    auditLinks: ["https://code4rena.com/reports/2026-04-monetrix"],
     twitter: "https://x.com/monetrix_xyz",
     wiki: "https://doc.monetrix.xyz/guide/mint",
     module: "monetrix-usdm",


### PR DESCRIPTION
## Summary
Attaches the Code4rena audit report to the Monetrix USDM stablecoin entry (id 404), so it surfaces under audits on the stablecoin listing page.

## Changes
- `src/peggedData/peggedData.ts`: set `auditLinks` on the Monetrix USDM entry from `null` to `["https://code4rena.com/reports/2026-04-monetrix"]`.

Single-line metadata change; no other fields touched.

## Audit
- Code4rena — Monetrix (2026-04): https://code4rena.com/reports/2026-04-monetrix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Code4rena audit link to the Monetrix USDM asset information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->