### PR TITLE
Add Stablecorp QCAD (QCAD) stablecoin adapter

### DIFF
--- a/src/adapters/peggedAssets/stablecorp-qcad/index.ts
+++ b/src/adapters/peggedAssets/stablecorp-qcad/index.ts
@@ -1,0 +1,15 @@
+const chainContracts = {
+  ethereum: {
+    issued: ["0x3fa142dd3f384414e05e71ad0939274edc82ec0a"],
+  },
+  base: {
+    issued: ["0xa15705e6fc8b3e08e7253f3758de1a754baa0761"],
+  },
+  solana: {
+    issued: ["EeBX9JLdvsp4HnBbMgC1HnAjBkBQxgxtWxspcCLtT6ci"],
+  },
+};
+
+import { addChainExports } from "../helper/getSupply";
+const adapter = addChainExports(chainContracts, undefined, { pegType: "peggedCAD" });
+export default adapter;

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8794,4 +8794,25 @@ export default [
     wiki: null,
     module: "decentralized-euro",
   },
+  {
+    id: "424",
+    name: "Stablecorp QCAD",
+    address: "0x3fa142dd3f384414e05e71ad0939274edc82ec0a",
+    symbol: "QCAD",
+    url: "https://stablecorp.ca/",
+    description:
+      "QCAD is Canada's first compliant CAD stablecoin, issued by Stablecorp and fully 1:1 fiat-backed by Canadian dollar reserves held with regulated Canadian financial institutions under a dedicated, third-party-audited trust.",
+    mintRedeemDescription:
+      "QCAD is minted 1:1 when users deposit Canadian dollars with the issuer and is redeemable 1:1 for CAD, with reserves held in a regulated Canadian trust and monthly attestation reports published.",
+    onCoinGecko: "true",
+    gecko_id: "stablecorp-qcad",
+    cmcId: null,
+    pegType: "peggedCAD",
+    pegMechanism: "fiat-backed",
+    priceSource: "defillama",
+    auditLinks: null,
+    twitter: "https://x.com/stablecorp",
+    wiki: null,
+    module: "stablecorp-qcad",
+  },
 ] as PeggedAsset[];


### PR DESCRIPTION
## Summary
Add Stablecorp QCAD (QCAD) stablecoin adapter on Ethereum, Base, and Solana
https://etherscan.io/token/0x3Fa142dD3f384414e05E71Ad0939274EdC82EC0A
https://basescan.org/token/0xa15705e6fc8b3e08e7253f3758de1a754baa0761
https://solscan.io/token/EeBX9JLdvsp4HnBbMgC1HnAjBkBQxgxtWxspcCLtT6ci

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Stablecorp QCAD (QCAD) as a pegged asset.
  - Added QCAD availability across Ethereum, Base, and Solana.
  - Included asset metadata, pricing information, and links for QCAD.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->