### PR TITLE
Add Base deployment to Macropod (AUDM) adapter and fix pegType to peg…

### DIFF
--- a/src/adapters/peggedAssets/macropod/index.ts
+++ b/src/adapters/peggedAssets/macropod/index.ts
@@ -8,8 +8,11 @@ const chainContracts: ChainContracts = {
   solana: {
     issued: ["CiYXBwHPrdNkMtxR8YEWKv78K6bQjFoEWhPQrZqEmubi"],
   },
+  base: {
+    issued: ["0xeded6ae915b129b67a4ad49901518f2736427063"],
+  },
 };
 import { addChainExports } from "../helper/getSupply";
 import { ChainContracts } from "../peggedAsset.type";
-const adapter = addChainExports(chainContracts);
+const adapter = addChainExports(chainContracts, undefined, { pegType: "peggedAUD" });
 export default adapter;


### PR DESCRIPTION
## Summary
Fix Macropod (AUDM) adapter to use peggedAUD and add its missing Base deployment
https://basescan.org/token/0xeded6ae915b129b67a4ad49901518f2736427063