### PR TITLE
Add multichain USDV supply adapters and reserve evidence

### DIFF
--- a/src/adapters/peggedAssets/valtorum-usdv/index.ts
+++ b/src/adapters/peggedAssets/valtorum-usdv/index.ts
@@ -21,15 +21,21 @@ const STELLAR_USDV_ISSUER =
 const chainContracts: ChainContracts = {
   tron: {
     issued: ["TAPR48oEGf6e8EqWsqSkLQ6wQKLfYimHGd"],
+    unreleased: [
+      "TTGKRCFPYpwuY4MU7NaVoqz2vWoUYy1gXG",
+    ],
   },
   base: {
     issued: ["0xB719f73b4a47Fa22e0fA00cedF5B7FB37f1e6866"],
+    unreleased: ["0x3c8d9271cc15a225bd3a1345c1412b76f12a3a4d"],
   },
   polygon: {
     issued: ["0x2b9bBfFCF4ACF9A5A545295bDF84713e477B28Cb"],
+    unreleased: ["0xd4bD9ffbba98ffA3E5F6a72b5240A9e315668910"],
   },
   bsc: {
     issued: ["0x96c2402d369C8C0aE1dFd4fA066F79F81A98A4b9"],
+    unreleased: ["0x2b5967F7Da644e046e202b62Be4b7192d0d6785b"],
   },
 };
 

--- a/src/adapters/peggedAssets/valtorum-usdv/index.ts
+++ b/src/adapters/peggedAssets/valtorum-usdv/index.ts
@@ -2,33 +2,51 @@ const axios = require("axios");
 const retry = require("async-retry");
 
 import { sumSingleBalance } from "../helper/generalUtil";
-import { Balances, PeggedIssuanceAdapter } from "../peggedAsset.type";
+import { addChainExports } from "../helper/getSupply";
+import {
+  Balances,
+  ChainContracts,
+  PeggedIssuanceAdapter,
+} from "../peggedAsset.type";
 
 const NODE_URL = "https://xrplcluster.com";
 const STELLAR_HORIZON = "https://horizon.stellar.org";
+const pegType = "peggedUSD";
 
 const USDV_ISSUER = "rfffsukWALJB1PXYk7H8xkR6UJUDT8nMJE";
 const USDV_CURRENCY = "5553445600000000000000000000000000000000";
-const STELLAR_USDV_ISSUER = "GBLAJOKBIIT7P32BJQFCSRJVOE2SXHI4D5ZGLFJ4DLMFJXI2NN6R37G5";
+const STELLAR_USDV_ISSUER =
+  "GBLAJOKBIIT7P32BJQFCSRJVOE2SXHI4D5ZGLFJ4DLMFJXI2NN6R37G5";
+
+const chainContracts: ChainContracts = {
+  tron: {
+    issued: ["TAPR48oEGf6e8EqWsqSkLQ6wQKLfYimHGd"],
+  },
+  base: {
+    issued: ["0xB719f73b4a47Fa22e0fA00cedF5B7FB37f1e6866"],
+  },
+  polygon: {
+    issued: ["0x2b9bBfFCF4ACF9A5A545295bDF84713e477B28Cb"],
+  },
+  bsc: {
+    issued: ["0x96c2402d369C8C0aE1dFd4fA066F79F81A98A4b9"],
+  },
+};
 
 async function minted() {
   const balances = {} as Balances;
   const payload = {
     method: "gateway_balances",
-    params: [
-      {
-        account: USDV_ISSUER,
-        ledger_index: "validated",
-      },
-    ],
+    params: [{ account: USDV_ISSUER, ledger_index: "validated" }],
   };
 
   const res = await retry(async (_bail: any) => axios.post(NODE_URL, payload));
   const supply = parseFloat(res.data.result.obligations[USDV_CURRENCY] ?? "0");
 
-  sumSingleBalance(balances, "peggedUSD", supply, "issued", false);
+  sumSingleBalance(balances, pegType, supply, "issued", false);
   return balances;
 }
+
 async function stellarMinted() {
   const balances = {} as Balances;
 
@@ -38,23 +56,25 @@ async function stellarMinted() {
     )
   );
 
-const record = res.data._embedded?.records?.[0];
-const supply = parseFloat(record?.balances?.authorized ?? "0")
-  + parseFloat(record?.balances?.authorized_to_maintain_liabilities ?? "0")
-  + parseFloat(record?.claimable_balances_amount ?? "0")
-  + parseFloat(record?.liquidity_pools_amount ?? "0")
-  + parseFloat(record?.contracts_amount ?? "0");
-  sumSingleBalance(balances, "peggedUSD", supply, "issued", false);
+  const record = res.data._embedded?.records?.[0];
+  const supply =
+    parseFloat(record?.balances?.authorized ?? "0") +
+    parseFloat(record?.balances?.authorized_to_maintain_liabilities ?? "0") +
+    parseFloat(record?.claimable_balances_amount ?? "0") +
+    parseFloat(record?.liquidity_pools_amount ?? "0") +
+    parseFloat(record?.contracts_amount ?? "0");
+
+  sumSingleBalance(balances, pegType, supply, "issued", false);
   return balances;
 }
+
 const adapter: PeggedIssuanceAdapter = {
+  ...addChainExports(chainContracts, undefined, { pegType }),
   ripple: {
     minted,
-    unreleased: async () => ({}),
   },
   stellar: {
     minted: stellarMinted,
-    unreleased: async () => ({}),
   },
 };
 

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8246,9 +8246,9 @@ export default [
     symbol: "USDV",
     url: "https://valtorum.com",
     description:
-      "Valtorum USD (USDV) is a permissioned USD-pegged stablecoin issued by Valtorum on the XRP Ledger. Holder trustlines require issuer authorization.",
+      "Valtorum USD (USDV) is a permissioned USD-pegged stablecoin issued by Valtorum across supported networks, including XRP Ledger, Stellar, TRON, Base, Polygon, and BNB Chain.",
     mintRedeemDescription:
-      "Valtorum USD is issued and redeemed by Valtorum through its XRP Ledger issuer account.",
+      "Valtorum USD is issued and redeemed by Valtorum through supported issuer and contract accounts, subject to Valtorum's terms and compliance requirements.",
     onCoinGecko: "false",
     gecko_id: "valtorum-usdv",
     cmcId: null,

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8255,7 +8255,7 @@ export default [
     pegType: "peggedUSD",
     pegMechanism: "fiat-backed",
     priceSource: "defillama",
-    auditLinks: [],
+    auditLinks: ["https://valtorum.com/por"],    
     twitter: null,
     wiki: "https://valtorum.com/about/",
     module: "valtorum-usdv",


### PR DESCRIPTION
Updates the existing Valtorum USD (USDV) listing.

Changes included:

- Adds USDV supply tracking for TRON
- Adds USDV supply tracking for Base
- Adds USDV supply tracking for Polygon
- Adds USDV supply tracking for BNB Chain
- Keeps existing XRP Ledger and Stellar supply tracking
- Updates USDV metadata to reflect the supported networks

The adapter uses DefiLlama's existing `addChainExports` helper for EVM/TRON supply reads and keeps the custom XRP Ledger/Stellar logic already used for those networks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded USDV tracking to cover additional networks beyond XRP Ledger and Stellar, improving visibility into cross-chain peg issuance.
  * Harmonized USDV minted and supply/balance reporting logic across the supported issuance sources for more consistent results.

* **Documentation**
  * Updated USDV asset descriptions to reflect multi-network issuance and redemption, including issuer/contract account context and applicable compliance terms.
  * Added an audit link for USDV references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->