### PR TITLE
kerne-usd: resolve kUSD (id 402) price from USDC instead of hardcoding it

### DIFF
--- a/src/adapters/peggedAssets/prices/index.ts
+++ b/src/adapters/peggedAssets/prices/index.ts
@@ -32,5 +32,9 @@ export async function getPrices(assets: any[]) {
   }
   finalRes["m-2"] = 1
   finalRes["terrausd"] = 0
+  // kUSD has no price feed yet. It is minted and redeemed 1:1 for USDC through an on-chain
+  // PSM, so read USDC's fetched price instead of pinning kUSD to a constant. If USDC does
+  // not resolve, kUSD stays unpriced rather than falling back to a hardcoded value.
+  if (finalRes["usd-coin"] !== undefined) finalRes["kerne-usd"] = finalRes["usd-coin"]
   return finalRes
 }


### PR DESCRIPTION
kUSD (peggedasset id 402, added in #819) is a USDC-backed stablecoin on Base. It is minted and redeemed 1:1 against USDC through an on-chain Peg Stability Module.

#863 fixed the chain prefix so the balance is now read on Base, and that merged, but the price still resolves null: coins.llama.fi returns no entry for `base:0x5C2EfdF0D8D286959b42308966bc2B97f5680AA3` and the gecko_id `kerne-usd` does not exist, so api.llama.fi shows kUSD with a null price on the stablecoins board.

This is the one-line follow-up I offered in [#863](https://github.com/DefiLlama/peggedassets-server/pull/863#issuecomment-4949745599): hardcode `finalRes["kerne-usd"] = 1`, directly beside the existing `finalRes["m-2"] = 1` precedent in the same file, so the peg reads 1.00. Because kUSD is 1:1 USDC redeemable through the PSM, 1.00 is the correct pegged price.

If you would rather point the price at USDC through a coins alias instead of hardcoding, I am happy to do that instead. No rush on either.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated pricing for the Kerne USD asset so it’s now populated using the already-fetched USD Coin price, instead of relying on a static fixed value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->