### PR TITLE
fix: saturn-dollar (USDat) Monad decimals  was defaulting to 18, actual is 6

### DIFF
--- a/src/adapters/peggedAssets/saturn-dollar/index.ts
+++ b/src/adapters/peggedAssets/saturn-dollar/index.ts
@@ -1,12 +1,12 @@
 const chainContracts = {
-    ethereum: {
-      issued: ["0x23238f20b894f29041f48D88eE91131C395Aaa71"],
-    },
-    monad: {
-      bridgedFromETH: ["0x0Bb150DFa86EA5d7742F07FEfCD8E8edA81D64eF"],
-    }
-  };
-  
-  import { addChainExports } from "../helper/getSupply";
-  const adapter = addChainExports(chainContracts);
-  export default adapter;
+  ethereum: {
+    issued: ["0x23238f20b894f29041f48D88eE91131C395Aaa71"],
+  },
+  monad: {
+    bridgedFromETH: ["0x0Bb150DFa86EA5d7742F07FEfCD8E8edA81D64eF"],
+  }
+};
+
+import { addChainExports } from "../helper/getSupply";
+const adapter = addChainExports(chainContracts, {}, { decimals: 6 });
+export default adapter;


### PR DESCRIPTION
**Bug:** `saturn-dollar/index.ts` calls `addChainExports(chainContracts)` with no options, so it falls back to the default `decimals: 18` for the Monad `bridgedFromETH` supply calculation. USDat is actually **6 decimals** on both chains.

**Verified:**
- `cast call 0x0Bb150DFa86EA5d7742F07FEfCD8E8edA81D64eF "decimals()(uint8)" --rpc-url <monad>` → `6`
- `cast call 0x23238f20b894f29041f48D88eE91131C395Aaa71 "decimals()(uint8)" --rpc-url <ethereum>` → `6` (same token, cross-chain)
- Live impact confirmed on stablecoins.llama.fi API: Monad `circulating` currently shows `5.707988285033796e-06` instead of the real ~5.62M (raw on-chain totalSupply 5,624,122,399,985 / 10^18 instead of /10^6 — a 10^12 undercount).

**Fix:** pass `{ decimals: 6 }` explicitly to `addChainExports`.

**After fix**, `npm run test saturn-dollar/index` shows Monad circulating = 5.62M, matching real on-chain supply.

Introduced in #870 (merged, added Monad support without setting decimals).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Saturn Dollar balances across supported chains.
  * Standardized the asset’s precision to six decimal places for more accurate display and calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->