### PR TITLE
Add JPYSC (trust-type JPY stablecoin) + fix JPYC circulating supply (add Kaia, exclude issuer/redemption wallets)

### DIFF
--- a/src/adapters/peggedAssets/jpycoin/index.ts
+++ b/src/adapters/peggedAssets/jpycoin/index.ts
@@ -1,26 +1,34 @@
-// V2 adapter for JPY Coin
+// V2 adapter for JPY Coin (fund-transfer-type JPYC issued by JPYC Inc.)
+// Same contract address on all chains.
+// Circulating = totalSupply - issuer wallet balance - redemption wallet balance.
+// The issuer wallet holds minted-but-not-yet-issued JPYC; the redemption wallet
+// holds JPYC returned by users for redemption that has not been burned yet.
+const issuerWallets = [
+  "0x8549e82239a88f463ab6e55ad1895b629a00def3", // issuer wallet
+  "0xb808af91bdc577bfb3f9c91470f3286dd076e5c1", // redemption wallet
+];
+
 const chainContracts = {
-    ethereum: {
-      issued: ["0xe7c3d8c9a439fede00d2600032d5db0be71c3c29"],
-      // unreleased: [
-      //   "0x8549E82239a88f463ab6E55Ad1895b629a00Def3",
-      // ],
-    },
-    avax: {
-      issued: ["0xe7c3d8c9a439fede00d2600032d5db0be71c3c29"],
-      // unreleased: [
-      //   "0x8549E82239a88f463ab6E55Ad1895b629a00Def3",
-      // ],
-    },
-    polygon: {
-      issued: ["0xe7c3d8c9a439fede00d2600032d5db0be71c3c29"],
-      // unreleased: [
-      //   "0x8549E82239a88f463ab6E55Ad1895b629a00Def3",
-      // ],
-    },
-  }
-  
-  import { addChainExports } from "../helper/getSupply";
-  const adapter = addChainExports(chainContracts, undefined, { pegType: "peggedJPY", });
-  export default adapter;
-  
+  ethereum: {
+    issued: ["0xe7c3d8c9a439fede00d2600032d5db0be71c3c29"],
+    unreleased: issuerWallets,
+  },
+  avax: {
+    issued: ["0xe7c3d8c9a439fede00d2600032d5db0be71c3c29"],
+    unreleased: issuerWallets,
+  },
+  polygon: {
+    issued: ["0xe7c3d8c9a439fede00d2600032d5db0be71c3c29"],
+    unreleased: issuerWallets,
+  },
+  klaytn: {
+    issued: ["0xe7c3d8c9a439fede00d2600032d5db0be71c3c29"],
+    unreleased: issuerWallets,
+  },
+};
+
+import { addChainExports } from "../helper/getSupply";
+const adapter = addChainExports(chainContracts, undefined, {
+  pegType: "peggedJPY",
+});
+export default adapter;

--- a/src/adapters/peggedAssets/jpysc/index.ts
+++ b/src/adapters/peggedAssets/jpysc/index.ts
@@ -1,0 +1,14 @@
+// JPYSC - trust-type Japanese Yen stablecoin issued by SBI Shinsei Trust & Banking
+// under Japan's Electronic Payment Instruments framework (trust-type).
+// Fully backed; circulating supply equals on-chain totalSupply.
+const chainContracts = {
+  ethereum: {
+    issued: ["0x6781d5631bfe47432b089e64e3eab3b6edd26177"],
+  },
+};
+
+import { addChainExports } from "../helper/getSupply";
+const adapter = addChainExports(chainContracts, undefined, {
+  pegType: "peggedJPY",
+});
+export default adapter;

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8857,4 +8857,25 @@ export default [
     wiki: null,
     module: "usd-2",
   },
+  {
+    id: "427",
+    name: "JPYSC",
+    address: "0x6781d5631bfe47432b089e64e3eab3b6edd26177",
+    symbol: "JPYSC",
+    url: "https://www.shinseitrust.com/stablecoin/jpysc.html",
+    description:
+      "JPYSC is a trust-type Japanese yen stablecoin issued by SBI Shinsei Trust & Banking under Japan's Electronic Payment Instruments framework, in partnership with Startale Group. Each JPYSC is fully backed 1:1 by Japanese yen held in trust.",
+    mintRedeemDescription:
+      "JPYSC is minted by SBI Shinsei Trust & Banking when Japanese yen is entrusted to the issuing trust, and redeemed 1:1 for yen through the trust; issuance and redemption are centrally controlled by the licensed trust bank.",
+    onCoinGecko: "true",
+    gecko_id: "jpysc",
+    cmcId: null,
+    pegType: "peggedJPY",
+    pegMechanism: "fiat-backed",
+    priceSource: "defillama",
+    auditLinks: null,
+    twitter: "https://x.com/JPYStableCoin",
+    wiki: null,
+    module: "jpysc",
+  },
 ] as PeggedAsset[];


### PR DESCRIPTION
This PR adds one new Japanese yen stablecoin and fixes the supply calculation of an existing one.

---
### 1. New listing: JPYSC

##### Name (to be shown on DefiLlama): JPYSC
##### Website Link: https://www.shinseitrust.com/stablecoin/jpysc.html
##### Logo: https://coin-images.coingecko.com/coins/images/102174247/large/jpysc_200.png
##### Chain: Ethereum
##### Coingecko ID: jpysc
##### Coinmarketcap ID: (not listed)
##### Short Description: JPYSC is a trust-type Japanese yen stablecoin issued by SBI Shinsei Trust & Banking (in partnership with Startale Group) under Japan's Electronic Payment Instruments framework, launched 2026-06-24. Each token is fully backed 1:1 by yen held in trust, with holder assets bankruptcy-remote by law. It is the first trust-bank-issued JPY stablecoin.
##### mintRedeemDescription: JPYSC is minted when Japanese yen is entrusted to SBI Shinsei Trust & Banking and redeemed 1:1 for yen through the trust; issuance and redemption are centrally controlled by the licensed trust bank.
##### Token address and ticker: 0x6781d5631bfe47432b089e64e3eab3b6edd26177 (Ethereum), JPYSC, 18 decimals
##### pegType: peggedJPY
##### pegMechanism: fiat-backed
##### priceSource: defillama
##### wiki: —
##### Twitter Link: https://x.com/JPYStableCoin
##### List of audit links if any: —

Circulating supply equals on-chain `totalSupply` (all minted tokens are fully backed by yen in trust; there is no pre-mint reserve wallet). Currently ~10.26B JPY. Independent tracker for cross-checking: https://jpysc-info.com

### 2. Fix: JPY Coin (id 355, `jpycoin`)

Two issues with the current adapter:
- **Kaia (klaytn) was missing.** JPYC uses the same contract address (0xe7c3d8c9a439fede00d2600032d5db0be71c3c29) on Ethereum / Polygon / Avalanche / Kaia. Kaia currently holds ~70% of JPYC's circulating supply (~1.70B of ~2.41B JPY), so the listing was missing its largest chain.
- **Issuer wallets were not excluded** (they were left commented out). Per the issuer's (JPYC Inc.) own circulating-supply definition, circulating = totalSupply − issuer wallet (0x8549e82239a88f463ab6e55ad1895b629a00def3, holds minted-but-not-yet-issued tokens) − redemption wallet (0xb808af91bdc577bfb3f9c91470f3286dd076e5c1, holds tokens returned for redemption pending burn). Without the exclusion the adapter overstates supply ~3.6x (8.81B vs 2.41B JPY).

Test output (`npx ts-node --transpile-only test.ts <folder> peggedJPY`, public RPCs, 2026-07-20):

jpysc:
- ethereum minted/circulating: 10.26 B (matches on-chain totalSupply 10,257,940,755)

jpycoin:
| chain | minted | unreleased | circulating |
|---|---|---|---|
| ethereum | 1.11 B | 940.75 M | 172.29 M |
| polygon | 3.76 B | 3.31 B | 447.16 M |
| avax | 431.75 M | 336.25 M | 95.50 M |
| klaytn | 3.50 B | 1.80 B | 1.70 B |
| **Total** | | 6.39 B | **2.41 B** |

Note: the production API currently shows JPY Coin at ~32.6M JPY, which matches neither the current adapter's theoretical output (~8.81B without exclusions) nor the corrected value (~2.41B) — there may be an additional pipeline issue worth checking on your side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking JPYSC, a fiat-backed Japanese yen stablecoin.
  * Added JPYSC asset metadata and supply tracking for its issued Ethereum contract.
* **Improvements**
  * Enhanced JPY Coin (peggedJPY) supply tracking across Ethereum, Avalanche, Polygon, and now also Klaytn by consistently sourcing issuer-related “unreleased” balances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->