### PR TITLE
stablecoins: exclude deadFrom assets from per-chain totals

### DIFF
--- a/api2/cron-task/getStablecoinChains.ts
+++ b/api2/cron-task/getStablecoinChains.ts
@@ -10,6 +10,11 @@ export function craftStablecoinChainsResponse() {
 
   peggedAssets.map((pegged) => {
       if (pegged.doublecounted) return;
+      // A dead asset stops receiving balance updates, so lastBalance is frozen at whatever
+      // it held on its final day. It also has no price, which makes the fallback below value
+      // every unit at par. storeCharts already refuses to extend these past their last real
+      // point; without the same check here the chain totals keep carrying them forever.
+      if (pegged.deadFrom) return;
       const pegType = pegged.pegType;
       const lastBalances = cache.peggedAssetsData?.[pegged.id]?.lastBalance;
       if (lastBalances === undefined) {

--- a/api2/cron-task/getStablecoinChains.ts
+++ b/api2/cron-task/getStablecoinChains.ts
@@ -11,6 +11,10 @@ export function craftStablecoinChainsResponse() {
 
   peggedAssets.map((pegged) => {
       if (pegged.doublecounted) return;
+      // dead assets are never re-run (storePegged skips them) and storeCharts stops extending
+      // them past their last real point, so lastBalance is frozen on their final day and the FX
+      // fallback below values every unit at par — the chain totals would carry them forever
+      if (pegged.deadFrom) return;
       const pegType = pegged.pegType;
       const lastBalances = cache.peggedAssetsData?.[pegged.id]?.lastBalance;
       if (lastBalances === undefined) {


### PR DESCRIPTION
`craftStablecoinChainsResponse` skips `doublecounted` assets but not `deadFrom` ones, so every asset the team has marked dead is still added to its chains' totals at whatever balance it last held.

Everywhere else in the repo a dead asset stops contributing:

- `src/peggedAssets/storePeggedAssets/storePegged.ts:32` — the adapter is never run again
- `src/peggedAssets/storePeggedAssets/storeNewPeggedBalances.ts:99` — balances are never stored
- `api2/cron-task/storeCharts.ts:239` — *"don't extend inactive assets beyond their last real data point"*

So `lastBalance` is frozen on the day the asset was marked dead, and this endpoint keeps counting it forever. Five of the dead assets that still carry a balance have no price left at all, and `fxFallbackPrice` returns `1` for `peggedUSD`, so those units are held at exactly $1.00.

### The same number, two endpoints, 1,716x apart

| endpoint | Waves stablecoins |
|---|---:|
| `/stablecoinchains` (this file) | $402,494,590 |
| `/stablecoincharts/Waves` (honours `deadFrom`) | $234,434 |

99.94% of the Waves total is Neutrino USD, marked dead 2023-02-01. On Waves today the asset `DG2xFkPdDwKUoBkzGAhQtLpSGzfXLiCYPEzeKH2Ad24p` is named **`XTN.`** — the peg was abandoned and the token renamed — with an on-chain supply of 289,747,010.72 and a price of $0.01586 (CoinGecko `neutrino`, pulled today). About $4.6M of real value is being reported as $402.26M.

smartBCH is the same shape: 99.99% of its $73.75M is flexUSD, dead since 2022-06-23. Its chart stopped on 2026-06-04 while the chains ranking still shows the full amount.

### Measured impact

Dead balances currently carried, from `/stablecoins?includePrices=true` reconciled against `/stablecoinchains`. `live + dead` reproduces each reported total to within 0.4%, which is what confirms this is the whole difference:

| chain | dead carried | reported total | dead share |
|---|---:|---:|---:|
| BSC | $530,917,231 | $13,902,735,251 | 3.82% |
| Waves | $402,258,803 | $402,494,598 | 99.94% |
| Ethereum | $317,174,052 | $147,837,215,758 | 0.21% |
| Arbitrum | $121,971,226 | $3,633,978,236 | 3.36% |
| Avalanche | $79,635,853 | $1,519,914,105 | 5.24% |
| smartBCH | $73,738,718 | $73,749,400 | 99.99% |
| OP Mainnet | $23,168,027 | $493,297,794 | 4.70% |
| Fantom | $18,931,569 | $337,437,442 | 5.61% |
| Polygon | $10,001,050 | $3,108,142,353 | 0.32% |
| Manta | $2,022,772 | $5,911,510 | 34.22% |
| Aurora | $609,110 | $4,623,064 | 13.18% |

Total across all chains: **$1,583,680,911**. Of that, $1,263,255,481 has no price at all and is held at par — USDX ($683.4M, dead 2025-11-14), USDN ($408.9M), USPD ($98.9M), sUSD ($69.8M) and syUSD ($2.2M).

The same gap exists in `api2/routes/getChainDominance.ts`, where it can also hand a chain's dominance to a collapsed asset — that one is #875.
