### PR TITLE
stablecoins: exclude deadFrom assets from chain dominance

### DIFF
--- a/api2/routes/getChainDominance.ts
+++ b/api2/routes/getChainDominance.ts
@@ -29,6 +29,12 @@ export function craftChainDominanceResponse(chain: string | undefined) {
   const lastRates = cache.rates
 
   const lastPeggedBalances = peggedAssets.map((pegged) => {
+      // Same exclusions the chain totals apply in craftStablecoinChainsResponse: a
+      // doublecounted asset is already represented by the collateral backing it, and a dead
+      // asset's lastBalance is frozen at its final day with no price, so it would be valued
+      // at par forever. Without these the dominance figures disagree with the chain totals.
+      if (pegged.doublecounted) return undefined;
+      if (pegged.deadFrom) return undefined;
       const lastBalance = cache.peggedAssetsData?.[pegged.id]?.lastBalance;
       if (!lastBalance?.[normalizedChain]) {
         return undefined;

--- a/api2/routes/getChainDominance.ts
+++ b/api2/routes/getChainDominance.ts
@@ -30,6 +30,10 @@ export function craftChainDominanceResponse(chain: string | undefined) {
   const lastRates = cache.rates
 
   const lastPeggedBalances = peggedAssets.map((pegged) => {
+      // dead assets keep a lastBalance frozen on their final day and most have no price left, so
+      // the par fallback below would hold them at face value forever and can even hand a chain's
+      // dominance to a collapsed asset; storeCharts already stops extending them
+      if (pegged.deadFrom) return undefined;
       const lastBalance = cache.peggedAssetsData?.[pegged.id]?.lastBalance;
       if (!lastBalance?.[normalizedChain]) {
         return undefined;


### PR DESCRIPTION
`craftChainDominanceResponse` never checks `deadFrom`, so an asset the team has marked dead still counts toward a chain's stablecoin total here — and can still be reported as that chain's **dominant** stablecoin.

A dead asset's adapter is never run again (`storePegged.ts:32`), its balances are never stored (`storeNewPeggedBalances.ts:99`), and `storeCharts.ts:239` refuses to extend it *"beyond their last real data point"*. This endpoint reads `lastBalance` directly, so it keeps the final frozen snapshot forever, and the `fallbackPrice = 1` path values it at par when the price is gone.

### What `/stablecoindominance` returns right now

| chain | dominant asset reported | mcap | status |
|---|---|---:|---|
| Waves | **USDN** | $402,258,803 | marked dead 2023-02-01 |
| smartBCH | **FLEXUSD** | $73,749,400 | marked dead 2022-06-23 |

On Waves the underlying asset `DG2xFkPdDwKUoBkzGAhQtLpSGzfXLiCYPEzeKH2Ad24p` is now named **`XTN.`** on-chain — Neutrino abandoned the dollar peg and renamed the token — with a supply of 289,747,010.72 and a price of $0.01586 (CoinGecko `neutrino`, pulled today), so roughly $4.6M of real value is being published as the chain's $402M dominant stablecoin. On smartBCH, flexUSD is 100% of the reported total.

With dead assets excluded, Waves' dominant stablecoin becomes USDT and smartBCH has none left.

### Measured impact

Dead balances currently carried by this endpoint, computed from `/stablecoins?includePrices=true`:

| chain | dead carried | dominance total now | after |
|---|---:|---:|---:|
| BSC | $530,917,231 | $18,175,451,577 | $17,644,534,346 |
| Waves | $402,258,803 | $402,494,549 | $235,745 |
| Ethereum | $317,174,052 | $149,376,385,452 | $149,059,211,400 |
| Arbitrum | $121,971,226 | $3,861,192,301 | $3,739,221,074 |
| Avalanche | $79,635,853 | $1,669,596,320 | $1,589,960,467 |
| smartBCH | $73,738,718 | $73,738,718 | $0 |
| OP Mainnet | $23,168,027 | $493,081,957 | $469,913,929 |
| Fantom | $18,931,569 | $337,298,719 | $318,367,150 |

Total: **$1,583,680,911**, of which $1,263,255,481 has no price and is held at exactly $1.00 — USDX ($683.4M), USDN ($408.9M), USPD ($98.9M), sUSD ($69.8M), syUSD ($2.2M).

This is the same gap as #874, which fixes it in `craftStablecoinChainsResponse`. Kept separate because they are different files.

I deliberately left `doublecounted` alone here even though `craftStablecoinChainsResponse` filters it: `storeCharts` treats it as an opt-in flag (`excludeDoublecounted`) and maintains both views, so which one dominance should use is a methodology call rather than a bug.
