### PR TITLE
tether: read Sui wormhole USDT on-chain instead of a dead API

### DIFF
--- a/src/adapters/peggedAssets/tether/index.ts
+++ b/src/adapters/peggedAssets/tether/index.ts
@@ -449,6 +449,14 @@ async function nearMint(address: string, decimals: number) {
   };
 }
 
+// Wormhole keeps a wrapped coin's TreasuryCap inside the token bridge's WrappedAsset, so
+// suix_getTotalSupply and coinMetadata don't expose the supply for it. The WrappedAsset is a
+// dynamic field on the token registry, which is the `token_registry` field of the bridge state
+// object 0xc57508ee0d4595e5a8728974a4a93a787d38f339757230d441e895422c07aba9.
+const SUI_WORMHOLE_TOKEN_BRIDGE = "0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d";
+const SUI_WORMHOLE_TOKEN_REGISTRY = "0x334881831bd89287554a6121087e498fa023ce52c037001b53a4563a00a281a5";
+const SUI_WORMHOLE_USDT = "0xc060006111016b8a020ad5b33834984a437aaa7d3c74c18e09a95d48aceab08c";
+
 async function suiWormholeBridged() {
   return async function (
     _timestamp: number,
@@ -456,9 +464,17 @@ async function suiWormholeBridged() {
     _chainBlocks: ChainBlocks
   ) {
     let balances = {} as Balances;
-    const res = await axios.get(`https://kx58j6x5me.execute-api.us-east-1.amazonaws.com/sui/usdt`)
-    const totalSupply = parseInt(res.data.find((t: any) => t.coin === "USDT_ETH").cumulative_balance);
-    sumSingleBalance(balances, "peggedUSD", totalSupply, "0xc060006111016b8a020ad5b33834984a437aaa7d3c74c18e09a95d48aceab08c", true);
+    const wrappedAsset = await sui.call("suix_getDynamicFieldObject", [
+      SUI_WORMHOLE_TOKEN_REGISTRY,
+      {
+        type: `${SUI_WORMHOLE_TOKEN_BRIDGE}::token_registry::Key<${SUI_WORMHOLE_USDT}::coin::COIN>`,
+        value: { dummy_field: false },
+      },
+    ]);
+    const wrapped = wrappedAsset.content.fields.value.fields;
+    const totalSupply =
+      Number(wrapped.treasury_cap.fields.total_supply.fields.value) / 10 ** Number(wrapped.decimals);
+    sumSingleBalance(balances, "peggedUSD", totalSupply, SUI_WORMHOLE_USDT, true);
     return balances;
   };
 }


### PR DESCRIPTION
USDT on Sui has reported nothing since 2026-06-25 and is currently stored as **0**.

### Cause

The Sui legs are combined into one key:

```ts
sui: {
  ethereum: sumMultipleBalanceFunctions([ suiWormholeBridged(), suiBridged ], "peggedUSD"),
}
```

and `sumMultipleBalanceFunctions` awaits each function in a bare loop:

```ts
for (let fnPromise of functions) {
  const fn = await fnPromise;
  const balance = await fn(timestamp, ethBlock, chainBlocks);   // no isolation
  mergeBalances(balances, pegType, balance);
}
```

`suiWormholeBridged` calls `https://kx58j6x5me.execute-api.us-east-1.amazonaws.com/sui/usdt`, which now returns **HTTP 500**. That throw propagates out of the combined function, so the healthy sibling — `suiBridged`, an on-chain read currently holding **8,521,102.80 USDT** — is lost with it, and the whole chain is dropped.

Running the current code and the two legs separately:

```
leg A  suiWormholeBridged  -> THROWS: Request failed with status code 500
leg B  suiBridged          -> OK  8,521,102.798257
combined sui.ethereum      -> THROWS  (entire chain lost)
```

### It is the combination, not the dead host

`usd-coin/index.ts` calls the **same** dead endpoint, but registers its Sui legs as five independent keys (`minted`, `ethereum`, `bsc`, `solana`, `arbitrum`). Each is stored separately, so the failing ones don't take down `suiMinted`. USDC on Sui reports normally — $271,755,387 today, with an unbroken daily series.

Tether's series, by contrast:

```
2026-06-24   13,221,239
2026-06-25   13,059,144
             ... no datapoint at all for 24 days ...
2026-07-20            0
```

### Reading the supply on-chain

Wormhole keeps a wrapped coin's `TreasuryCap` inside the token bridge's `WrappedAsset`, so the usual calls can't see it:

```
suix_getTotalSupply(0xc060...::coin::COIN)  -> "Cannot find object with type 0x2::coin::TreasuryCap<...>"
suix_getCoinMetadata(...)                   -> decimals 6, symbol USDT, but no supply
```

The `WrappedAsset` is a dynamic field on the token registry, which is the `token_registry` field of the bridge state object `0xc57508ee0d4595e5a8728974a4a93a787d38f339757230d441e895422c07aba9` — I read that object to derive the registry id `0x3348...` rather than assuming it. Reading the field gives `decimals: 6`, `info.symbol: "USDT"`, `treasury_cap.total_supply.value: 1372167048035` → **1,372,167.05 USDT**.

### Result

```
before:  sui.ethereum THROWS  (chain stored as 0)
after:   {"peggedUSD":9893269.846292,
          "bridges":{"wormhole":{"Ethereum":{"amount":1372167.048035}},
                     "issued":{"not-found":{"amount":8521102.798257}}}}
```

The shape matches the last healthy production record (`bridges.issued["not-found"]` + `bridges.wormhole.Ethereum`), so bridge attribution downstream is unchanged.

**$9.89M** of USDT circulating on Sui, restored. Because the leg is keyed `ethereum`, the missing amount also isn't being subtracted from Ethereum's USDT circulating while it's dropped.

Worth noting the dead API was serving stale data before it failed: its last value was 1,687,448 on 2026-06-25, against 1,372,167 on-chain now, and it was byte-identical across 2026-06-21..06-25.

`tsc --noEmit` gives the same 50 pre-existing errors before and after, none in this file. The `axios` import stays — nine other call sites still use it.

Related but not conflicting: open PR #791 adds `tether/wormholeConfig.ts`; this touches `tether/index.ts`.
