### PR TITLE
Disambiguate duplicate stablecoin names

### DIFF
--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -984,7 +984,7 @@ export default [
   },
   {
     id: "46",
-    name: "USD+",
+    name: "Overnight USD+",
     address: "polygon:0x236eec6359fb44cce8f97e99387aa7f8cd5cde1f",
     symbol: "USD+",
     url: "https://overnight.fi/",
@@ -4106,7 +4106,7 @@ export default [
   },
   {
     id: "192",
-    name: "USDA",
+    name: "Angle USDA",
     address: "0x0000206329b97db379d5e1bf586bbdb969c63274",
     symbol: "USDA",
     url: "https://angle.money/usda",
@@ -8392,7 +8392,7 @@ export default [
   },
   {
     id: "405",
-    name: "USDA",
+    name: "AP USDA",
     address: "bsc:0x17eafd08994305d8ace37efb82f1523177ec70ee",
     symbol: "USDA",
     url: "https://alphapartner.vip/",
@@ -8838,7 +8838,7 @@ export default [
   },
   {
     id: "426",
-    name: "USD+",
+    name: "Streamflow USD+",
     address: "solana:usdsfJbX78ktZUnoRC7dwvvQz7xH3WdkpGne76gdUia",
     symbol: "USD+",
     url: "https://usd-plus.com/",


### PR DESCRIPTION
Two pairs of stablecoins shared the exact same display name, so the generated API config collapsed each pair onto one route and made the other asset unreachable.

This updates the source names to include their issuers:
- Overnight USD+ and Streamflow USD+
- Angle USDA and AP USDA

Because routes are derived from names, the existing config now emits four distinct entries without frontend collision handling or a new slug override contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stablecoin labels to clearly distinguish assets with shared symbols, including Overnight USD+, Angle USDA, AP USDA, and Streamflow USD+.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->