### PR TITLE
Add peggedKRW support and KRWQ adapter

### DIFF
--- a/src/adapters/peggedAssets/krwt/index.ts
+++ b/src/adapters/peggedAssets/krwt/index.ts
@@ -1,0 +1,40 @@
+import {
+  addChainExports,
+  solanaMintedOrBridged,
+} from "../helper/getSupply";
+import type { PeggedIssuanceAdapter } from "../peggedAsset.type";
+
+const pegType = "peggedKRW" as const;
+
+const chainContracts = {
+  ethereum: {
+    issued: ["0xc00db6b41473d065027f5ed6fada20fde75f142e"],
+  },
+  base: {
+    bridgedFromETH: ["0x370923d39f139c64813f173a1bf0b4f9ba36a24f"],
+  },
+  polygon: {
+    bridgedFromETH: ["0x44c3950a6ed303c863a6568ea18c1a01e504ffd2"],
+  },
+  fraxtal: {
+    bridgedFromETH: ["0xbe5b2eb217bb04a7ddd1a451e6a1567dc15e2fd6"],
+  },
+  morph: {
+    bridgedFromETH: ["0xe898e1cffa565aae8bacc364aa7d65d6a2d20f16"],
+  },
+  codex: {
+    bridgedFromETH: ["0xe898e1cffa565aae8bacc364aa7d65d6a2d20f16"],
+  },
+};
+
+const adapter: PeggedIssuanceAdapter = {
+  ...addChainExports(chainContracts, undefined, { pegType }),
+  solana: {
+    ethereum: solanaMintedOrBridged(
+      ["GSuBmsfco2DGNLSxHhgbFH1MaEfzqexDWq3aJs9XufkF"],
+      pegType
+    ),
+  },
+};
+
+export default adapter;

--- a/src/adapters/peggedAssets/peggedAsset.type.ts
+++ b/src/adapters/peggedAssets/peggedAsset.type.ts
@@ -31,7 +31,8 @@ export type PeggedAssetType =
   | "peggedXOF"
   | "peggedGHS"
   | "peggedCLP"
-  | "peggedPEN";
+  | "peggedPEN"
+  | "peggedKRW";
 
 type StringNumber = string;
 type PeggedBalances = {

--- a/src/peggedData/bridgeData.ts
+++ b/src/peggedData/bridgeData.ts
@@ -1719,6 +1719,26 @@ export default {
     bridge: "layerzero",
     sourceChain: formattedSourceChains.eth,
   },
+    "0x370923d39f139c64813f173a1bf0b4f9ba36a24f": {
+    bridge: "layerzero",
+    sourceChain: formattedSourceChains.eth,
+  },
+  "0x44c3950a6ed303c863a6568ea18c1a01e504ffd2": {
+    bridge: "layerzero",
+    sourceChain: formattedSourceChains.eth,
+  },
+  "0xbe5b2eb217bb04a7ddd1a451e6a1567dc15e2fd6": {
+    bridge: "layerzero",
+    sourceChain: formattedSourceChains.eth,
+  },
+  "0xe898e1cffa565aae8bacc364aa7d65d6a2d20f16": {
+    bridge: "layerzero",
+    sourceChain: formattedSourceChains.eth,
+  },
+  "GSuBmsfco2DGNLSxHhgbFH1MaEfzqexDWq3aJs9XufkF": {
+    bridge: "layerzero",
+    sourceChain: formattedSourceChains.eth,
+  },
   "25c5de5f5b286073c593edfd77b48abc7a48e5a4f3d4cd9d428ff93555534454": {
     bridge: "wan",
     sourceChain: formattedSourceChains.eth,

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8878,4 +8878,25 @@ export default [
     wiki: "https://jpysc-info.com/jpysc",
     module: "jpysc",
   },
+  {
+    id: "428",
+    name: "KRWQ",
+    address: "0xc00db6b41473d065027f5ed6fada20fde75f142e",
+    symbol: "KRWQ",
+    url: "https://www.krwq.cash/",
+    description:
+      "KRWQ is a fully reserved Korean won-denominated stablecoin developed by IQ in partnership with Frax. It is designed to track one Korean won and is backed by disclosed reserve assets including Korean Treasury Bonds and approved stablecoins.",
+    mintRedeemDescription:
+      "Eligible KYC-approved counterparties can mint KRWQ after the issuer receives fiat or approved collateral and redeem it through partner services; redeemed KRWQ is burned.",
+    onCoinGecko: "true",
+    gecko_id: "krwt",
+    cmcId: "38807",
+    pegType: "peggedKRW",
+    pegMechanism: "fiat-backed",
+    priceSource: "coingecko",
+    auditLinks: null,
+    twitter: "https://x.com/krwqcash",
+    wiki: "https://www.krwq.cash/whitepaper.pdf",
+    module: "krwt",
+  },
 ] as PeggedAsset[];

--- a/src/peggedData/types.ts
+++ b/src/peggedData/types.ts
@@ -25,6 +25,7 @@ type PegType =
   | "peggedGHS" //Ghanaian cedi
   | "peggedCLP" //chilean peso
   | "peggedPEN" //peruvian sol
+  | "peggedKRW" //South Korean won
 
 type PegMechanism = "algorithmic" | "fiat-backed" | "crypto-backed";
 


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

(fill in below form only for new listings)

##### Name (to be shown on DefiLlama):

KRWQ

##### Website Link:

https://www.krwq.cash/

##### Logo (High resolution, will be shown with rounded borders):

https://www.krwq.cash/krwq-logo.png

##### Chain:

Ethereum, Base, Polygon, Fraxtal, Morph, Codex, Solana

##### Coingecko ID (leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

krwt

##### Coinmarketcap ID (leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

38807

##### Short Description:

KRWQ is a fully reserved Korean won-denominated stablecoin developed by IQ in partnership with Frax. It is designed to track one Korean won and is backed by disclosed reserve assets including Korean Treasury Bonds and approved stablecoins.

##### mintRedeemDescription:

Eligible KYC-approved counterparties can mint KRWQ after the issuer receives fiat or approved collateral and redeem it through partner services; redeemed KRWQ is burned.

##### Token address and ticker:

Ticker: KRWQ

- Ethereum: `0xc00db6b41473d065027f5ed6fada20fde75f142e`
- Base: `0x370923d39f139c64813f173a1bf0b4f9ba36a24f`
- Polygon: `0x44c3950a6ed303c863a6568ea18c1a01e504ffd2`
- Fraxtal: `0xbe5b2eb217bb04a7ddd1a451e6a1567dc15e2fd6`
- Morph: `0xe898e1cffa565aae8bacc364aa7d65d6a2d20f16`
- Codex: `0xe898e1cffa565aae8bacc364aa7d65d6a2d20f16`
- Solana: `GSuBmsfco2DGNLSxHhgbFH1MaEfzqexDWq3aJs9XufkF`

##### pegType:

peggedKRW

##### pegMechanism:

fiat-backed

##### priceSource:

coingecko

##### wiki:

https://www.krwq.cash/whitepaper.pdf

##### Twitter Link:

https://x.com/krwqcash

##### List of audit links if any:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the KRWQ Korean won–pegged stablecoin.
  * Added KRWQ metadata, fiat-backed peg details, market data mappings, and integration links.
  * Added cross-chain tracking across supported EVM networks and Solana.
  * Added LayerZero bridge mappings for the new asset.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->