### PR TITLE
Add ENSC (Naira Stablecoin) fiat peggedNGN stablecoin

### DIFF
--- a/src/adapters/peggedAssets/ensc/index.ts
+++ b/src/adapters/peggedAssets/ensc/index.ts
@@ -1,0 +1,27 @@
+// eNsc - Naira Stablecoin (fiat-backed, 1:1 NGN).
+// Same canonical address on every chain via deterministic deploy; each chain is
+// a native issuance point (no bridge wrapping), so every chain is `issued`.
+// 1:1 fiat-backed with nothing held uncirculated -> unreleased is empty and
+// circulating == totalSupply.
+//
+// NOTE: ENSC has no CoinGecko id yet, so this folder is named with the slug
+// `ensc` rather than a gecko id.
+
+const ENSC = "0xF50FFf154E63E510e494929E9eab1E9C5047429E";
+
+const chainContracts = {
+  lisk:     { issued: [ENSC], unreleased: [] },
+  optimism: { issued: [ENSC], unreleased: [] },
+  bsc:      { issued: [ENSC], unreleased: [] },
+  polygon:  { issued: [ENSC], unreleased: [] },
+  base:     { issued: [ENSC], unreleased: [] },
+  mode:     { issued: [ENSC], unreleased: [] },
+  arbitrum: { issued: [ENSC], unreleased: [] },
+};
+
+import { addChainExports } from "../helper/getSupply";
+
+export default addChainExports(chainContracts, undefined, {
+  pegType: "peggedNGN",
+  decimals: 18,
+});

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8880,4 +8880,25 @@ export default [
     wiki: "https://jpysc-info.com/jpysc",
     module: "jpysc",
   },
+  {
+    id: "428",
+    name: "Naira Stablecoin",
+    address: "0xF50FFf154E63E510e494929E9eab1E9C5047429E",
+    symbol: "ENSC",
+    url: "https://prosperavest.com/ensc",
+    description:
+      "eNsc is a Real-World Asset (RWA) stablecoin issued by ProsperaVest & pegged 1:1 with the Nigerian Naira reserves. More than just a digital Naira, eNsc powers payments/settlement rails and provides institutional access to tokenized Nigerian Treasuries.",
+    mintRedeemDescription:
+      "eNsc is minted 1:1 against fiat naira deposits with ProsperaVest and redeemed 1:1 for the naira.",
+    onCoinGecko: "false",
+    gecko_id: null,
+    cmcId: null,
+    pegType: "peggedNGN",
+    pegMechanism: "fiat-backed",
+    priceSource: "defillama",
+    auditLinks: ["https://prosperavest.com/transparency"],
+    twitter: "https://x.com/prosperavest",
+    wiki: "https://whitepaper.prosperavest.com/ensc/the-naira-stablecoin-engnsc",
+    module: "ensc",
+  },
 ] as PeggedAsset[];


### PR DESCRIPTION
ENSC has no CoinGecko listing yet(currently tracked on geckoterminal); gecko_id is null and the adapter is resolved via `module: "ensc"`. Priced on-chain via totalSupply; tested ~1.16M circulating (live on Lisk, contracts deployed on the other six chains).

##### Name (to be shown on DefiLlama): Naira Stablecoin
##### Website Link: https://prosperavest.com/ensc
##### Logo (High resolution, will be shown with rounded borders): https://cdn.prosperavest.com/logo/eNsc.png
##### Chain: Lisk, Optimism, BSC, Polygon, Base, Mode, Arbitrum
##### Coingecko ID (not listed): 
##### Coinmarketcap ID (not listed): 
##### Short Description: eNsc is a NGN-pegged fiat-backed RWA stablecoin issued by ProsperaVest, used for payments/settlement and access to tokenized Real World Assets (RWAs) such as the Nigerian Treasuries.
##### mintRedeemDescription: eNsc is minted 1:1 against fiat naira deposits with ProsperaVest and redeemed 1:1 for the naira.
##### Token address and ticker: 0xF50FFf154E63E510e494929E9eab1E9C5047429E - ENSC
##### pegType: peggedNGN
##### pegMechanism: fiat-backed
##### priceSource: defillama
##### wiki: https://whitepaper.prosperavest.com/ensc/the-naira-stablecoin-engnsc
##### Twitter Link: https://x.com/prosperavest
##### List of audit links if any: https://prosperavest.com/transparency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Naira Stablecoin (ENSC), a Nigerian naira-backed stablecoin.
  * Added ENSC availability across Lisk, Optimism, BNB Smart Chain, Polygon, Base, Mode, and Arbitrum.
  * Included ENSC metadata and reference links in the pegged-asset listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->