### PR TITLE
kerne-usd: exclude PSM-held kUSD from circulating supply

### DIFF
--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -12112,6 +12112,14 @@ export default [
       chains: {
         base: {
           issued: ["0x5C2EfdF0D8D286959b42308966bc2B97f5680AA3"],
+          // Peg Stability Modules. Redemptions transfer kUSD into the PSM
+          // without burning it, so PSM-held kUSD is protocol inventory, not
+          // circulating supply.
+          unreleased: [
+            "0xFf3025ec18e301855aB0f36Ec6ECa115a29A5Fbc",
+            "0x07eBb486e11BD217e6085eb5ab663e4517595993",
+            "0xaBDE1138aa1Ce88d1dF06422C0c3b05D70569803",
+          ],
         },
       },
     },


### PR DESCRIPTION
Targeting `consolidate` rather than `master` because #882 removes `src/adapters/peggedAssets/kerne-usd/index.ts`, and this is the same change expressed in the new `chainConfig` form. If you would rather land it on `master` first I can push it as the equivalent adapter edit instead, just say which you prefer.

### The defect

Kerne's PSM contracts receive redeemed kUSD without burning it, so redeemed tokens accumulate inside the module as protocol inventory. The config only declares `issued`, so that inventory is still counted as circulating supply.

Today that overstates circulating by 32 kUSD, and it makes the asset read as undercollateralised against its own reserves: 1,144.707154 circulating against 1,113.885006 USDC held by the PSM is 97.31%. The PSM-held kUSD is not a claim on those reserves. Excluding it gives 1,112.707154 and 100.11%.

### The change

Declares the three PSM addresses as `unreleased`, so `getUnreleased` subtracts their balances. `minted` is untouched.

| address | role | kUSD held |
| --- | --- | --- |
| `0xFf3025ec18e301855aB0f36Ec6ECa115a29A5Fbc` | redeem PSM | 32.000000 |
| `0x07eBb486e11BD217e6085eb5ab663e4517595993` | retired mint PSM | 0 |
| `0xaBDE1138aa1Ce88d1dF06422C0c3b05D70569803` | live mint PSM | 0 |

The two zero balance modules are included so the figure stays correct as inventory moves between them, which is why `alchemix-usd` and `hyperliquid-native-stablecoin` list every reserve address rather than only the funded one.

### Verified

Base block 49151769:

* `kUSD.totalSupply` 1,144.707154
* PSM held 32.000000
* circulating after this change 1,112.707154

Harness output, `npx ts-node --transpile-only test.ts 402 peggedUSD`:

```
--- base ---
minted                    1.14 k
circulating               1.11 k
unreleased                32.00

------ NO EXTRAPOLATION ------
```

Reserves are published at https://kerne.fi/api/por, which returns the `cast` commands to recompute every balance above from chain.
