### PR TITLE
Add KRW1 stablecoin adapter

### DIFF
--- a/src/adapters/peggedAssets/krw1/index.ts
+++ b/src/adapters/peggedAssets/krw1/index.ts
@@ -1,0 +1,15 @@
+import { addChainExports } from "../helper/getSupply";
+
+// Track the production contract reconciled to the issuer's transparency report.
+// Older multichain proof-of-concept deployments are intentionally excluded.
+const chainContracts = {
+  ethereum: {
+    issued: ["0xb83fc84df7028251066c25f5d61d12fd9d9c8be4"],
+  },
+};
+
+const adapter = addChainExports(chainContracts, undefined, {
+  pegType: "peggedKRW",
+});
+
+export default adapter;

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -8901,4 +8901,25 @@ export default [
     wiki: "https://www.krwq.cash/whitepaper.pdf",
     module: "krwt",
   },
+  {
+    id: "429",
+    name: "KRW1",
+    address: "0xb83fc84df7028251066c25f5d61d12fd9d9c8be4",
+    symbol: "KRW1",
+    url: "https://krw1.kr/",
+    description:
+      "KRW1 is a Korean won-denominated stablecoin issued by BDACS and backed 1:1 by Korean won reserves held in segregated bank accounts.",
+    mintRedeemDescription:
+      "BDACS mints KRW1 after receiving Korean won into segregated bank accounts and burns tokens when users redeem them for won through its compliance-controlled service.",
+    onCoinGecko: "true",
+    gecko_id: "krw1",
+    cmcId: null,
+    pegType: "peggedKRW",
+    pegMechanism: "fiat-backed",
+    priceSource: "defillama",
+    auditLinks: null,
+    twitter: "https://x.com/BDACSKorea",
+    wiki: "https://krw1.kr/pdf/BDACS_KRW1_White%20Paper_EN.pdf",
+    module: "krw1",
+  },
 ] as PeggedAsset[];


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

(fill in below form only for new listings)

##### Name (to be shown on DefiLlama):

KRW1

##### Website Link:

https://krw1.kr/

##### Logo (High resolution, will be shown with rounded borders):

https://krw1.kr/download/Logo_v1.1.png

##### Chain:

Ethereum

##### Coingecko ID (leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

krw1

##### Coinmarketcap ID (leave empty if not listed):


##### Short Description:

KRW1 is a Korean won-denominated stablecoin issued by BDACS and backed 1:1 by Korean won reserves held in segregated bank accounts.

##### mintRedeemDescription:

BDACS mints KRW1 after Korean won is deposited into segregated reserve accounts and burns KRW1 when it is redeemed for Korean won.

##### Token address and ticker:

Ticker: KRW1

- Ethereum: `0xb83fc84df7028251066c25f5d61d12fd9d9c8be4`

##### pegType:

peggedKRW

##### pegMechanism:

fiat-backed

##### priceSource:

defillama

##### wiki:

https://krw1.kr/pdf/BDACS_KRW1_White%20Paper_EN.pdf

##### Twitter Link:

https://x.com/BDACSKorea

##### List of audit links if any:


### Implementation notes

- This adapter tracks the current production Ethereum contract.
- The issuer’s transparency page reports 1,000,000 KRW1 in circulation, matching the contract’s on-chain `totalSupply`.
- Older multichain PoC deployments are excluded because they do not reconcile with the current issuer-reported reserve and production supply.
- KRW1 currently has no active market price, so `defillama` is used as the KRW reference-price source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking the KRW1 pegged asset.
  * Added KRW1 metadata, pricing information, redemption details, and reference links.
  * Added Ethereum contract coverage for KRW1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->