### PR TITLE
aznd

### DIFF
--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -9841,6 +9841,7 @@ export default [
         },
       },
     },
+    delisted: true, // Mu Digital orderly wind-down 2026-07; peg broken (no market price, unredeemable at $1) — stop reporting monad supply at face value
   },
   {
     id: "328",


### PR DESCRIPTION
AZND mcap is more like 3M$ because it depeged a couple of weeks ago, suggestion to either delist or correct the mcap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Mu Digital’s status to reflect its delisting and orderly wind-down.
  * Mu Digital will no longer be reported at face value following its peg break.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->