### PR TITLE
Add auditLinks for Kerne USD (kUSD, id 402)

### DIFF
--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -12105,7 +12105,7 @@ export default [
     pegType: "peggedUSD",
     pegMechanism: "crypto-backed",
     priceSource: "defillama",
-    auditLinks: [],
+    auditLinks: ["https://github.com/kerne-protocol/contracts-public/blob/main/audits/hexens-kerne-protocol-final-2026-07-31.pdf"],
     twitter: "https://twitter.com/KerneProtocol",
     wiki: "https://kerne.fi/docs",
     doublecounted: true,


### PR DESCRIPTION
This is a one line change to an existing entry rather than a new listing, so I have left the new listing form blank.

Kerne Protocol completed its first external audit with Hexens. The final report was published on 2026-07-31, and `auditLinks` on entry `id: "402"` (Kerne USD, kUSD) was still empty.

Report: https://github.com/kerne-protocol/contracts-public/blob/main/audits/hexens-kerne-protocol-final-2026-07-31.pdf

29 pages, 10 findings (0 critical, 2 high, 2 medium, 4 low, 2 informational), 8 fixed and 2 acknowledged. The PDF is committed verbatim in the protocol's public contracts repository, so the link is stable and the file is hash checkable.

For transparency: I have a separate support ticket open with DefiLlama about the `audits` field on the protocol record (slug `kerne`, id 7873), which lives outside this repo. This PR only touches the stablecoin record's `auditLinks` and does not depend on that ticket.

Allow edits by maintainers is enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a link to Kerne USD’s Hexens audit report in its audit information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->