### PR TITLE
Expose stablecoin dead dates in list API

### DIFF
--- a/api2/cron-task/getStableCoins.ts
+++ b/api2/cron-task/getStableCoins.ts
@@ -155,6 +155,7 @@ function craftProtocolsResponse(
         ),
         ...(pegged.deprecated ? { deprecated: true } : {}),
         ...(pegged.yieldBearing ? { yieldBearing: true } : {}),
+        ...(pegged.deadFrom ? { deadFrom: pegged.deadFrom } : {}),
       } as any;
       dataToReturn.price = prices[pegged.gecko_id] ?? null;
       if (pegged.delisted) dataToReturn.delisted = true;


### PR DESCRIPTION
## What changed

- Adds the producer-owned `deadFrom` date to affected assets in the `/stablecoins` response.
- Keeps the field absent for active assets.

## Why

Stablecoin charts correctly stop inactive assets at their configured lifecycle date, but the list API did not expose that state. Consumers could therefore present an asset’s last historical market cap as if it were current.

This is an additive metadata change. It does not alter balances, historical charts, lifecycle rules, or active assets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stablecoin protocol responses now include the asset’s defined “dead from” value when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->