### PR TITLE
feat: add stablecoins v2 api

### DIFF
--- a/api2/cron-task/index.ts
+++ b/api2/cron-task/index.ts
@@ -16,6 +16,7 @@ import { storeRouteData } from "../file-cache";
 import { chainCacheSlug } from "../utils/cachePath";
 import { craftChainDominanceResponse } from "../routes/getChainDominance";
 import { getStablecoinData } from "../routes/getStableCoin";
+import { buildV2Files } from "../v2/build";
 import storeStablecoins from "./getStableCoins";
 import { craftStablecoinChainsResponse } from "./getStablecoinChains";
 import { craftStablecoinPricesResponse } from "./getStablecoinPrices";
@@ -69,6 +70,8 @@ async function run() {
   await storeRouteData('stablecoincharts2/all-dominance-chain-breakdown', { dominanceMap, chainChartMap, })
   await storeRouteData('stablecoincharts2/recent-protocol-data', recentProtocolData)
   await saveCache()
+
+  await buildV2Files()
 
   async function storePeggedAssets() {
     for (const peggedAssetData of allStablecoinsData.peggedAssets) {

--- a/api2/routes/index.ts
+++ b/api2/routes/index.ts
@@ -4,6 +4,7 @@ import { successResponse, errorResponse, errorWrapper as ew } from "./utils";
 import { readRouteData } from "../file-cache";
 import { normalizeChain } from "../../src/utils/normalizeChain";
 import { chainCacheSlug } from "../utils/cachePath";
+import { setV2Routes } from "../v2/routes";
 
 const ACCEL_PREFIX = '/_internal/cache'
 const behindNginx = !!process.env.API_STORAGE_HOST
@@ -13,6 +14,8 @@ const breakdownData: {
 } = {}
 
 export default function setRoutes(router: HyperExpress.Router) {
+
+  setV2Routes(router)
 
   router.get("/config", defaultFileHandler);
   router.get("/rates", defaultFileHandler);

--- a/api2/v2/build.ts
+++ b/api2/v2/build.ts
@@ -142,7 +142,7 @@ async function assertSourcesNotRegressed(chainLabels: string[], listed: [any, As
     })
   ).filter(Boolean);
   const publishedSlugs = async (dir: string) =>
-    (await fs.promises.readdir(getRouteDataPath(dir)).catch(() => [] as string[])).filter((f) => !f.endsWith(".br"));
+    (await fs.promises.readdir(getRouteDataPath(dir)).catch(() => [] as string[])).filter((f) => !/\.(br|tmp)$/.test(f));
   const publishedChains = await publishedSlugs("v2/history/market-cap/daily/by-asset-chain");
   const publishedAssets = await publishedSlugs("v2/asset");
   const nowChains = new Set(chainLabels.map(chainSlugFromLabel));
@@ -256,9 +256,6 @@ export async function buildV2Files() {
       : Array.isArray(previousAssets?.assets)
       ? previousAssets.assets.length
       : 0;
-  if (previousCount && sourceAssets.length < previousCount / 2) {
-    throw new Error(`v2 build: asset count collapsed ${previousCount} -> ${sourceAssets.length} - refusing to publish`);
-  }
 
   const latestRates: Record<string, number> = rates?.[rates.length - 1]?.rates ?? {};
   const referenceUsdFor = (info: AssetInfo): number | null => {
@@ -302,6 +299,13 @@ export async function buildV2Files() {
       continue;
     }
     listed.push([a, info]);
+  }
+
+  if (!listed.length) {
+    throw new Error(`v2 build: none of the ${sourceAssets.length} /stablecoins assets resolved against peggedData - refusing to publish an empty dataset`);
+  }
+  if (previousCount && listed.length < previousCount / 2) {
+    throw new Error(`v2 build: asset count collapsed ${previousCount} -> ${listed.length} - refusing to publish`);
   }
 
   // pre-flight: refuse to publish if a source that previously published artifacts is now unreadable

--- a/api2/v2/build.ts
+++ b/api2/v2/build.ts
@@ -1,0 +1,639 @@
+import fs from "fs";
+import path from "path";
+import zlib from "zlib";
+import * as sdk from "@defillama/sdk";
+import { readRouteData, getRouteDataPath } from "../file-cache";
+import { pegTypeFxTicker } from "../../src/utils/fxRates";
+import {
+  AssetInfo,
+  RESOLUTIONS,
+  Resolution,
+  Tuple,
+  assetRegistry,
+  chainSlugFromLabel,
+  identitySeriesFields,
+  pointsToTuples,
+  sampleTuples,
+  sumRecord,
+  sumRecordOrNull,
+} from "./shared";
+
+const round = Math.round;
+
+function toTuple(ts: any, value: any): Tuple | null {
+  const t = typeof ts === "number" ? ts : Number(ts);
+  if (!Number.isFinite(t) || typeof value !== "number" || !Number.isFinite(value)) return null;
+  return [t, round(value)];
+}
+
+function sortDedupe(tuples: Tuple[]): Tuple[] {
+  tuples.sort((a, b) => a[0] - b[0]);
+  const out: Tuple[] = [];
+  for (const t of tuples) {
+    if (out.length && out[out.length - 1][0] === t[0]) out[out.length - 1] = t;
+    else out.push(t);
+  }
+  return out;
+}
+
+let writtenPaths = new Set<string>();
+
+const BR_MIN_BYTES = 1024;
+const brotli = (buf: Buffer): Promise<Buffer> =>
+  new Promise((resolve, reject) =>
+    zlib.brotliCompress(
+      buf,
+      { params: { [zlib.constants.BROTLI_PARAM_QUALITY]: 5, [zlib.constants.BROTLI_PARAM_SIZE_HINT]: buf.length } },
+      (err: any, out: Buffer) => (err ? reject(err) : resolve(out))
+    )
+  );
+
+async function writeAtomic(filePath: string, buf: Buffer) {
+  const tmp = filePath + ".tmp";
+  await fs.promises.writeFile(tmp, buf);
+  await fs.promises.rename(tmp, filePath);
+}
+
+async function writeV2(subPath: string, data: any) {
+  const filePath = getRouteDataPath(`v2/${subPath}`);
+  await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+  const buf = Buffer.from(JSON.stringify(data));
+  // .br is written/removed before the plain file is visible, so reads never see a mismatched pair
+  if (buf.length >= BR_MIN_BYTES) {
+    await writeAtomic(filePath + ".br", await brotli(buf));
+    writtenPaths.add(subPath + ".br");
+  } else {
+    await fs.promises.unlink(filePath + ".br").catch(() => {});
+  }
+  await writeAtomic(filePath, buf);
+  writtenPaths.add(subPath);
+}
+
+const IO_CONCURRENCY = 8;
+async function mapPool<T, R>(items: T[], limit: number, fn: (item: T, index: number) => Promise<R>): Promise<R[]> {
+  const out: R[] = new Array(items.length);
+  let next = 0;
+  const worker = async () => {
+    for (let i = next++; i < items.length; i = next++) out[i] = await fn(items[i], i);
+  };
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return out;
+}
+
+async function sweepOrphans(): Promise<string[]> {
+  const root = getRouteDataPath("v2");
+  const removed: string[] = [];
+  const walk = async (dir: string) => {
+    let entries: fs.Dirent[];
+    try {
+      entries = await fs.promises.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        await walk(full);
+        continue;
+      }
+      const rel = path.relative(root, full);
+      if (rel === "_manifest") continue;
+      if (writtenPaths.has(rel)) continue;
+      const gone = await fs.promises
+        .unlink(full)
+        .then(() => true)
+        .catch(() => false);
+      if (gone) removed.push(rel);
+    }
+  };
+  await walk(root);
+  return removed;
+}
+
+const exists = (filePath: string): Promise<boolean> =>
+  fs.promises
+    .access(filePath)
+    .then(() => true)
+    .catch(() => false);
+
+async function assertSourcesNotRegressed(chainLabels: string[], listed: [any, AssetInfo][]) {
+  const lostChains = (
+    await mapPool(chainLabels, IO_CONCURRENCY, async (label) => {
+      const slug = chainSlugFromLabel(label);
+      if (await exists(getRouteDataPath(`stablecoincharts2/${slug}`))) return null;
+      // no source now - was there an artifact from a previous build?
+      return (await exists(getRouteDataPath(`v2/history/market-cap/daily/by-asset-chain/${slug}`))) ? slug : null;
+    })
+  ).filter(Boolean);
+  const lostAssets = (
+    await mapPool(listed, IO_CONCURRENCY, async ([, info]) => {
+      if (await exists(getRouteDataPath(`stablecoin/${info.id}`))) return null;
+      return (await exists(getRouteDataPath(`v2/asset/${info.slug}`))) ? info.slug : null;
+    })
+  ).filter(Boolean);
+  if (!lostChains.length && !lostAssets.length) return;
+  const detail = `chains [${lostChains.join(", ") || "none"}], assets [${lostAssets.join(", ") || "none"}]`;
+  if (process.env.STABLECOINS_V2_ALLOW_SOURCE_REGRESSION === "1") {
+    console.error(`v2 build: source regression accepted via STABLECOINS_V2_ALLOW_SOURCE_REGRESSION: ${detail}`);
+    return;
+  }
+  throw new Error(
+    `v2 build: ${lostChains.length + lostAssets.length} source(s) that previously published artifacts are now ` +
+      `unreadable - refusing to publish a build with holes in it: ${detail}. ` +
+      `The previous build is left intact and will be served until it ages out. If this is a genuine delisting, ` +
+      `rerun once with STABLECOINS_V2_ALLOW_SOURCE_REGRESSION=1.`
+  );
+}
+
+type SeriesEntry = { data: Tuple[]; [key: string]: any };
+
+function sortSeries(series: SeriesEntry[]): SeriesEntry[] {
+  const last = (s: SeriesEntry) => (s.data.length ? s.data[s.data.length - 1][1] : -Infinity);
+  return series.filter((s) => s.data.length).sort((a, b) => last(b) - last(a));
+}
+
+// writes {unit, data} or {unit, series} under every resolution
+async function writeHistory(pathFor: (res: Resolution) => string, generatedAt: number, unit: string, payload: { data?: Tuple[]; series?: SeriesEntry[] }) {
+  await mapPool(RESOLUTIONS, RESOLUTIONS.length, async (res) => {
+    const out: any = { generatedAt, unit };
+    if (payload.data) out.data = sampleTuples(payload.data, res);
+    else out.series = sortSeries((payload.series ?? []).map((s) => ({ ...s, data: sampleTuples(s.data, res) })));
+    await writeV2(pathFor(res), out);
+  });
+}
+
+export async function buildV2Files() {
+  const generatedAt = Math.floor(Date.now() / 1e3);
+  const reg = assetRegistry();
+  const stats = {
+    written: 0,
+    missingChainFiles: [] as string[],
+    missingAssetFiles: [] as string[],
+    removed: 0,
+    droppedPoints: 0,
+    sweepSkipped: false,
+    derivedVolume: 0,
+  };
+  writtenPaths = new Set<string>();
+
+  const [stablecoins, stablecoinChains, chartsAll, domFile, rates] = await Promise.all([
+    readRouteData("stablecoins"),
+    readRouteData("stablecoinchains"),
+    readRouteData("stablecoincharts2/all"),
+    readRouteData("stablecoincharts2/all-dominance-chain-breakdown"),
+    readRouteData("rates"),
+  ]);
+
+  // guard on content not key presence - an empty-but-present source would otherwise publish an empty dataset as healthy
+  const sourceAssets: any[] = Array.isArray(stablecoins?.peggedAssets) ? stablecoins.peggedAssets : [];
+  const breakdownIds = chartsAll?.breakdown && typeof chartsAll.breakdown === "object" ? Object.keys(chartsAll.breakdown) : [];
+  if (!sourceAssets.length) throw new Error("v2 build: /stablecoins has no peggedAssets - refusing to publish an empty dataset");
+  if (!breakdownIds.length) throw new Error("v2 build: stablecoincharts2/all has an empty breakdown - refusing to publish an empty dataset");
+  if (!Array.isArray(stablecoinChains) || !stablecoinChains.length) {
+    throw new Error("v2 build: /stablecoinchains is empty - refusing to publish an empty dataset");
+  }
+
+  const previousManifest = await readRouteData("v2/_manifest");
+  const previousAssets = await readRouteData("v2/assets");
+  const previousCount =
+    typeof previousManifest?.assets === "number"
+      ? previousManifest.assets
+      : Array.isArray(previousAssets?.assets)
+      ? previousAssets.assets.length
+      : 0;
+  if (previousCount && sourceAssets.length < previousCount / 2) {
+    throw new Error(`v2 build: asset count collapsed ${previousCount} -> ${sourceAssets.length} - refusing to publish`);
+  }
+
+  const latestRates: Record<string, number> = rates?.[rates.length - 1]?.rates ?? {};
+  const referenceUsdFor = (info: AssetInfo): number | null => {
+    if (info.pegType === "peggedUSD") return 1;
+    if (info.pegType === "peggedVAR") return null;
+    const rate = latestRates[pegTypeFxTicker(info.pegType)];
+    return rate && isFinite(1 / rate) ? 1 / rate : null;
+  };
+
+  const chainLabels: string[] = (stablecoinChains ?? []).map((c: any) => c.name);
+  const doubleIds = new Set<string>((chartsAll.doublecountedIds ?? []).map(String));
+
+  // ---------- current-data snapshots ----------
+
+  const snapshotOf = (a: any, info: AssetInfo, scope?: any) => ({
+    id: info.id,
+    slug: info.slug,
+    name: info.name,
+    symbol: info.symbol,
+    geckoId: info.geckoId,
+    pegCurrency: info.pegCurrency,
+    pegMechanism: info.pegMechanism,
+    priceUsd: typeof a.price === "number" ? a.price : null,
+    referenceUsd: referenceUsdFor(info),
+    circulatingUsd: sumRecordOrNull(scope ? scope.current : a.circulating) ?? 0,
+    circulatingUsdPrevDay: sumRecordOrNull(scope ? scope.circulatingPrevDay : a.circulatingPrevDay),
+    circulatingUsdPrevWeek: sumRecordOrNull(scope ? scope.circulatingPrevWeek : a.circulatingPrevWeek),
+    circulatingUsdPrevMonth: sumRecordOrNull(scope ? scope.circulatingPrevMonth : a.circulatingPrevMonth),
+    chains: (a.chains ?? []).map(chainSlugFromLabel),
+    ...(info.doublecounted ? { doublecounted: true } : {}),
+    ...(info.deprecated ? { deprecated: true } : {}),
+    ...(info.delisted ? { delisted: true } : {}),
+    ...(info.yieldBearing ? { yieldBearing: true } : {}),
+  });
+
+  const listed: [any, AssetInfo][] = [];
+  for (const a of stablecoins.peggedAssets) {
+    const info = reg.byId.get(String(a.id));
+    if (!info) {
+      console.error(`v2 build: /stablecoins asset id ${a.id} missing from peggedData`);
+      continue;
+    }
+    listed.push([a, info]);
+  }
+
+  // pre-flight: refuse to publish if sources regressed (skipping just the sweep isn't enough); only counts as regression if a previous build published that entity
+  await assertSourcesNotRegressed(chainLabels, listed);
+
+  await writeV2("assets", {
+    generatedAt,
+    assets: listed.map(([a, info]) => snapshotOf(a, info)).sort((x, y) => y.circulatingUsd - x.circulatingUsd),
+  });
+  stats.written++;
+
+  for (const label of chainLabels) {
+    const scoped = listed
+      .map(([a, info]) => {
+        const chainScope = a.chainCirculating?.[label];
+        if (!chainScope) return null;
+        return snapshotOf(a, info, chainScope);
+      })
+      .filter(Boolean) as any[];
+    await writeV2(`assets-chain/${chainSlugFromLabel(label)}`, {
+      generatedAt,
+      assets: scoped.sort((x, y) => y.circulatingUsd - x.circulatingUsd),
+    });
+    stats.written++;
+  }
+
+  // chains snapshot: totals from /stablecoinchains, prev* from the per-chain series, dominant asset from dominanceMap
+  const chainChartMap = domFile?.chainChartMap ?? {};
+  const dominanceMap = domFile?.dominanceMap ?? {};
+  const valueAtOffset = (tuples: Tuple[], last: number, offsetDays: number): number | null => {
+    const target = last - offsetDays * 86400;
+    let best: Tuple | null = null;
+    for (const t of tuples) {
+      // closest record within 1.5 days, same tolerance class as v1 snapshot offsets
+      if (Math.abs(t[0] - target) <= 86400 * 1.5 && (!best || Math.abs(t[0] - target) < Math.abs(best[0] - target))) best = t;
+    }
+    return best ? best[1] : null;
+  };
+  const chainsOut = (stablecoinChains ?? []).map((c: any) => {
+    const tuples = pointsToTuples(chainChartMap[c.name] ?? [], "totalCirculatingUSD");
+    const lastTs = tuples.length ? tuples[tuples.length - 1][0] : 0;
+    const domPoints = dominanceMap[c.name] ?? [];
+    const greatest = domPoints.length ? domPoints[domPoints.length - 1]?.greatestMcap : null;
+    const domAsset = greatest?.gecko_id ? reg.byGeckoId.get(greatest.gecko_id) : null;
+    return {
+      slug: chainSlugFromLabel(c.name),
+      name: c.name,
+      circulatingUsd: round(sumRecord(c.totalCirculatingUSD)),
+      circulatingUsdPrevDay: tuples.length ? valueAtOffset(tuples, lastTs, 1) : null,
+      circulatingUsdPrevWeek: tuples.length ? valueAtOffset(tuples, lastTs, 7) : null,
+      circulatingUsdPrevMonth: tuples.length ? valueAtOffset(tuples, lastTs, 30) : null,
+      dominantAsset: greatest
+        ? { slug: domAsset?.slug ?? null, symbol: greatest.symbol, circulatingUsd: round(greatest.mcap) }
+        : null,
+    };
+  });
+  await writeV2("chains", { generatedAt, chains: chainsOut.sort((a: any, b: any) => b.circulatingUsd - a.circulatingUsd) });
+  stats.written++;
+
+  // ---------- market-cap histories ----------
+
+  // global total excludes doublecounted (v1 aggregated does not - sum the clean series instead)
+  const globalByDate = new Map<number, number>();
+  const assetSeriesGlobal: SeriesEntry[] = [];
+  for (const [id, points] of Object.entries(chartsAll.breakdown)) {
+    const info = reg.byId.get(id);
+    if (!info) continue;
+    const tuples = pointsToTuples(points as any[], "totalCirculatingUSD");
+    assetSeriesGlobal.push({ ...identitySeriesFields(info), data: tuples });
+    if (!doubleIds.has(id)) for (const [ts, v] of tuples) globalByDate.set(ts, (globalByDate.get(ts) ?? 0) + v);
+    await writeHistory((r) => `history/market-cap/${r}/total-asset/${info.slug}`, generatedAt, "usd", { data: tuples });
+    stats.written += 3;
+  }
+  const globalTotal: Tuple[] = [...globalByDate.entries()].sort((a, b) => a[0] - b[0]).map(([t, v]) => [t, round(v)]);
+  await writeHistory((r) => `history/market-cap/${r}/total`, generatedAt, "usd", { data: globalTotal });
+  await writeHistory((r) => `history/market-cap/${r}/by-asset`, generatedAt, "usd", { series: assetSeriesGlobal });
+  stats.written += 6;
+
+  const chainSeriesGlobal: SeriesEntry[] = Object.entries(chainChartMap).map(([label, points]) => ({
+    slug: chainSlugFromLabel(label),
+    name: label,
+    data: pointsToTuples(points as any[], "totalCirculatingUSD"),
+  }));
+  await writeHistory((r) => `history/market-cap/${r}/by-chain`, generatedAt, "usd", { series: chainSeriesGlobal });
+  stats.written += 3;
+  for (const s of chainSeriesGlobal) {
+    await writeHistory((r) => `history/market-cap/${r}/total-chain/${s.slug}`, generatedAt, "usd", { data: s.data });
+    stats.written += 3;
+  }
+
+  // per-chain asset breakdowns + per-asset chain breakdowns, one pass over the v1 chain files
+  const perAssetChains = new Map<string, SeriesEntry[]>();
+  for (const label of chainLabels) {
+    const chainSlug = chainSlugFromLabel(label);
+    const chainFile = await readRouteData(`stablecoincharts2/${chainSlug}`);
+    if (!chainFile?.breakdown) {
+      stats.missingChainFiles.push(chainSlug);
+      continue;
+    }
+    const series: SeriesEntry[] = [];
+    for (const [id, points] of Object.entries(chainFile.breakdown)) {
+      const info = reg.byId.get(id);
+      if (!info) continue;
+      const tuples = pointsToTuples(points as any[], "totalCirculatingUSD");
+      if (!tuples.length) continue;
+      series.push({ ...identitySeriesFields(info), data: tuples });
+      if (!perAssetChains.has(id)) perAssetChains.set(id, []);
+      perAssetChains.get(id)!.push({ slug: chainSlug, name: label, data: tuples });
+    }
+    await writeHistory((r) => `history/market-cap/${r}/by-asset-chain/${chainSlug}`, generatedAt, "usd", { series });
+    stats.written += 3;
+  }
+  for (const [id, series] of perAssetChains) {
+    const info = reg.byId.get(id)!;
+    await writeHistory((r) => `history/market-cap/${r}/by-chain-asset/${info.slug}`, generatedAt, "usd", { series });
+    stats.written += 3;
+  }
+
+  // ---------- supply histories (raw token counts, from the v1 asset detail files) ----------
+
+  // one unit of work per asset; misses are collected and folded back afterwards for deterministic stats
+  const assetMisses = await mapPool(listed, IO_CONCURRENCY, async ([listedAsset, info]) => {
+    const detail = await readRouteData(`stablecoin/${info.id}`);
+    if (!detail) return info.slug;
+    // both variants share one walk of the token array: they differ only by the unreleased addend
+    const tuplesBoth = (tokens: any[]): { plain: Tuple[]; unreleased: Tuple[] } => {
+      const plain: Tuple[] = [];
+      const unreleased: Tuple[] = [];
+      for (const t of tokens ?? []) {
+        if (!t || t.circulating === undefined) continue;
+        const circulating = sumRecord(t.circulating);
+        const a = toTuple(t.date, circulating);
+        const b = toTuple(t.date, circulating + sumRecord(t.unreleased));
+        if (a && b) {
+          plain.push(a);
+          unreleased.push(b);
+        } else stats.droppedPoints++;
+      }
+      return { plain: sortDedupe(plain), unreleased: sortDedupe(unreleased) };
+    };
+    const totals = tuplesBoth(detail.tokens);
+    const chainEntries = Object.entries(detail.chainBalances ?? {}).map(([label, v]: [string, any]) => ({
+      slug: chainSlugFromLabel(label),
+      name: label,
+      both: tuplesBoth(v?.tokens ?? []),
+    }));
+    const chainSeriesFor = (key: "plain" | "unreleased"): SeriesEntry[] =>
+      chainEntries.map((c) => ({ slug: c.slug, name: c.name, data: c.both[key] }));
+    await writeHistory((r) => `history/supply/${r}/${info.slug}/total`, generatedAt, "count", { data: totals.plain });
+    await writeHistory((r) => `history/supply/${r}/${info.slug}/total-unreleased`, generatedAt, "count", { data: totals.unreleased });
+    await writeHistory((r) => `history/supply/${r}/${info.slug}/by-chain`, generatedAt, "count", { series: chainSeriesFor("plain") });
+    await writeHistory((r) => `history/supply/${r}/${info.slug}/by-chain-unreleased`, generatedAt, "count", { series: chainSeriesFor("unreleased") });
+    stats.written += 4 * RESOLUTIONS.length;
+
+    // circulatingUsd must match /v2/assets' source or directory and detail pages disagree; only unpriced quantities are converted here
+    const priceUsd = typeof detail.price === "number" ? detail.price : null;
+    const refUsd = referenceUsdFor(info);
+    const price = priceUsd ?? refUsd ?? 0;
+    const lastOf = (tokens: any[]) => (tokens?.length ? tokens[tokens.length - 1] : null);
+    const chainsCurrent = Object.entries(detail.chainBalances ?? {})
+      .map(([label, v]: [string, any]) => {
+        const last = lastOf(v?.tokens ?? []);
+        if (!last) return null;
+        const scope = listedAsset.chainCirculating?.[label];
+        return {
+          slug: chainSlugFromLabel(label),
+          name: label,
+          circulatingUsd: scope ? sumRecordOrNull(scope.current) ?? 0 : round(sumRecord(last.circulating) * price),
+          unreleasedUsd: round(sumRecord(last.unreleased) * price),
+          bridgedInUsd: round(sumRecord(last.bridgedTo) * price),
+          mintedUsd: round(sumRecord(last.minted) * price),
+        };
+      })
+      .filter(Boolean)
+      .sort((a: any, b: any) => b.circulatingUsd - a.circulatingUsd);
+    const globalLast = lastOf(detail.tokens);
+    const raw = info.raw;
+    await writeV2(`asset/${info.slug}`, {
+      generatedAt,
+      id: info.id,
+      slug: info.slug,
+      name: info.name,
+      symbol: info.symbol,
+      geckoId: info.geckoId,
+      cmcId: raw.cmcId ?? null,
+      address: raw.address ?? null,
+      pegCurrency: info.pegCurrency,
+      pegMechanism: info.pegMechanism,
+      priceSource: raw.priceSource ?? null,
+      priceUsd,
+      referenceUsd: refUsd,
+      description: raw.description ?? null,
+      mintRedeemDescription: raw.mintRedeemDescription ?? null,
+      url: raw.url ?? null,
+      twitter: raw.twitter ?? null,
+      wiki: raw.wiki ?? null,
+      auditLinks: raw.auditLinks ?? raw.audit_links ?? [],
+      onCoinGecko: raw.onCoinGecko === "true" || raw.onCoinGecko === true,
+      circulatingUsd: sumRecordOrNull(listedAsset.circulating) ?? 0,
+      unreleasedUsd: globalLast ? round(sumRecord(globalLast.unreleased) * price) : 0,
+      ...(info.doublecounted ? { doublecounted: true } : {}),
+      ...(info.deprecated ? { deprecated: true } : {}),
+      ...(info.delisted ? { delisted: true } : {}),
+      ...(info.yieldBearing ? { yieldBearing: true } : {}),
+      ...(info.deadFrom ? { deadFrom: info.deadFrom } : {}),
+      chains: chainsCurrent,
+    });
+    stats.written++;
+    return null;
+  });
+  for (const slug of assetMisses) if (slug) stats.missingAssetFiles.push(slug);
+
+  // ---------- volume histories (1:1 transforms of the v1 volume files) ----------
+  await buildVolume(generatedAt, reg, stats);
+
+  // sweep only runs if no sources regressed vs the previous build - a missing source could be delisted or just unreadable, and deleting on the latter is catastrophic
+  const prevMissingChains = typeof previousManifest?.missingChainSources === "number" ? previousManifest.missingChainSources : Infinity;
+  const prevMissingAssets = typeof previousManifest?.missingAssetSources === "number" ? previousManifest.missingAssetSources : Infinity;
+  const degraded = stats.missingChainFiles.length > prevMissingChains || stats.missingAssetFiles.length > prevMissingAssets;
+  if (degraded) {
+    stats.sweepSkipped = true;
+    console.error(
+      `v2 build: SOURCES REGRESSED (chains ${prevMissingChains} -> ${stats.missingChainFiles.length}, ` +
+        `assets ${prevMissingAssets} -> ${stats.missingAssetFiles.length}) - skipping orphan sweep to avoid ` +
+        `deleting still-good data. Missing chains: ${stats.missingChainFiles.join(", ") || "none"}; ` +
+        `missing assets: ${stats.missingAssetFiles.join(", ") || "none"}`
+    );
+  }
+  const removed = degraded ? [] : await sweepOrphans();
+  stats.removed = removed.length;
+
+  // `_manifest` is written LAST - it's the only proof a run completed; serving relies on that
+  await writeV2("_manifest", {
+    generatedAt,
+    files: writtenPaths.size,
+    assets: listed.length,
+    chains: chainLabels.length,
+    missingChainSources: stats.missingChainFiles.length,
+    missingAssetSources: stats.missingAssetFiles.length,
+  });
+
+  console.log(
+    `v2 build done: ${stats.written} files, ${removed.length} orphans removed` +
+      (stats.missingChainFiles.length ? `; missing chain sources: ${stats.missingChainFiles.length}` : "") +
+      (stats.missingAssetFiles.length ? `; missing asset sources: ${stats.missingAssetFiles.length}` : "")
+  );
+  return stats;
+}
+
+async function buildVolume(generatedAt: number, reg: ReturnType<typeof assetRegistry>, stats: any) {
+  const volumeDir = getRouteDataPath("volume");
+  let files: string[] = [];
+  try {
+    files = await fs.promises.readdir(volumeDir);
+  } catch {
+    console.error("v2 build: no volume files found, skipping volume endpoints");
+    return;
+  }
+  // filter to names the v1 writer actually produces - a stray .tmp/.br file would leak into a route path
+  files = files.filter((f) => !/\.(tmp|br)$/.test(f));
+  const readVolume = (name: string) => readRouteData(`volume/${name}`);
+
+  const totalTuples = (rows: any[]): Tuple[] => {
+    const out: Tuple[] = [];
+    for (const r of rows ?? []) {
+      const tuple = Array.isArray(r) ? toTuple(r[0], r[1]) : null;
+      if (tuple) out.push(tuple);
+      else stats.droppedPoints++;
+    }
+    return sortDedupe(out);
+  };
+
+  // breakdown rows [[ts, {key: value}]] -> one series per key
+  const breakdownSeries = (rows: any[], identityFor: (key: string) => any): SeriesEntry[] => {
+    const byKey = new Map<string, Tuple[]>();
+    for (const row of rows ?? []) {
+      if (!Array.isArray(row)) {
+        stats.droppedPoints++;
+        continue;
+      }
+      const [ts, values] = row;
+      for (const [key, value] of Object.entries(values ?? {})) {
+        const tuple = toTuple(ts, value);
+        if (!tuple) {
+          stats.droppedPoints++;
+          continue;
+        }
+        if (!byKey.has(key)) byKey.set(key, []);
+        byKey.get(key)!.push(tuple);
+      }
+    }
+    return [...byKey.entries()].map(([key, data]) => ({ ...identityFor(key), data: sortDedupe(data) }));
+  };
+
+  const assetIdentity = (symbol: string) => {
+    const matches = reg.bySymbol.get(symbol.toUpperCase()) ?? [];
+    // volume source data is keyed by token symbol; only a unique match gets asset identity
+    if (matches.length === 1) return { id: matches[0].id, slug: matches[0].slug, name: matches[0].name, symbol: matches[0].symbol };
+    return { slug: null, name: symbol, symbol };
+  };
+  // breakdown keys are chain keys ("optimism"); resolve to a display label
+  const chainIdentity = (key: string) => {
+    const name = sdk.chainUtils.getChainLabelFromKey(key);
+    return { slug: chainSlugFromLabel(name), name };
+  };
+  // slugs from volume filenames are label-slugs, not chain keys - resolve via chain list, not getChainLabelFromKey (mangles them, e.g. "op-mainnet" -> "Op-mainnet")
+  const labelBySlug = new Map<string, string>();
+  for (const label of Object.values(sdk.chainUtils.chainKeyToChainLabelMap ?? {}) as string[]) {
+    if (label) labelBySlug.set(chainSlugFromLabel(label), label);
+  }
+  const chainIdentityFromSlug = (slug: string) => ({ slug, name: labelBySlug.get(slug) ?? sdk.chainUtils.getChainLabelFromKey(slug) });
+  const currencyIdentity = (code: string) => ({ slug: code.toLowerCase(), name: code.toUpperCase() });
+
+  const writeIf = async (rows: any, pathFor: (r: Resolution) => string, payload: { data?: Tuple[]; series?: SeriesEntry[] }) => {
+    if (!rows) return;
+    await writeHistory(pathFor, generatedAt, "usd", payload);
+    stats.written += 3;
+  };
+
+  const [totalRows, chainBreakdown, tokenBreakdown, currencyBreakdown] = await Promise.all([
+    readVolume("chart-total"),
+    readVolume("chart-total-chain-breakdown"),
+    readVolume("chart-total-token-breakdown"),
+    readVolume("chart-total-currency-breakdown"),
+  ]);
+  // each breakdown is pivoted once, reused by its own endpoint and the derived families below
+  const chainSeries = chainBreakdown ? breakdownSeries(chainBreakdown, chainIdentity) : [];
+  const tokenSeries = tokenBreakdown ? breakdownSeries(tokenBreakdown, assetIdentity) : [];
+  if (totalRows) await writeIf(totalRows, (r) => `history/volume/${r}/total`, { data: totalTuples(totalRows) });
+  if (chainBreakdown) await writeIf(chainBreakdown, (r) => `history/volume/${r}/by-chain`, { series: chainSeries });
+  if (tokenBreakdown) await writeIf(tokenBreakdown, (r) => `history/volume/${r}/by-asset`, { series: tokenSeries });
+  if (currencyBreakdown) await writeIf(currencyBreakdown, (r) => `history/volume/${r}/by-pegcurrency`, { series: breakdownSeries(currencyBreakdown, currencyIdentity) });
+
+  // asset -> per-chain volume series, pivoted out of the per-chain token breakdowns below
+  const perAssetChainVolume = new Map<string, SeriesEntry[]>();
+
+  for (const file of files) {
+    if (file.startsWith("chart-chain-")) {
+      const rest = file.slice("chart-chain-".length);
+      if (rest.endsWith("-token-breakdown")) {
+        const chainSlug = rest.slice(0, -"-token-breakdown".length);
+        const rows = await readVolume(file);
+        const series = breakdownSeries(rows, assetIdentity);
+        await writeIf(rows, (r) => `history/volume/${r}/chain/${chainSlug}/by-asset`, { series });
+        for (const s of series) {
+          if (!s.slug || !s.data.length) continue; // ambiguous symbol: not attributable to one asset
+          if (!perAssetChainVolume.has(s.slug)) perAssetChainVolume.set(s.slug, []);
+          perAssetChainVolume.get(s.slug)!.push({ ...chainIdentityFromSlug(chainSlug), data: s.data });
+        }
+      } else if (rest.endsWith("-currency-breakdown")) {
+        const chainSlug = rest.slice(0, -"-currency-breakdown".length);
+        const rows = await readVolume(file);
+        await writeIf(rows, (r) => `history/volume/${r}/chain/${chainSlug}/by-pegcurrency`, { series: breakdownSeries(rows, currencyIdentity) });
+      } else {
+        const rows = await readVolume(file);
+        await writeIf(rows, (r) => `history/volume/${r}/chain/${rest}/total`, { data: totalTuples(rows) });
+      }
+    } else if (file.startsWith("chart-token-")) {
+      const rest = file.slice("chart-token-".length);
+      const isChainBreakdown = rest.endsWith("-chain-breakdown");
+      const symbol = isChainBreakdown ? rest.slice(0, -"-chain-breakdown".length) : rest;
+      const matches = reg.bySymbol.get(symbol.toUpperCase()) ?? [];
+      if (matches.length !== 1) continue; // ambiguous or unknown symbol: not routable by asset slug
+      const slug = matches[0].slug;
+      const rows = await readVolume(file);
+      if (isChainBreakdown) await writeIf(rows, (r) => `history/volume/${r}/asset/${slug}/by-chain`, { series: breakdownSeries(rows, chainIdentity) });
+      else await writeIf(rows, (r) => `history/volume/${r}/asset/${slug}/total`, { data: totalTuples(rows) });
+    }
+  }
+
+  // derives routes with no dedicated v1 source file from the breakdowns above; dedicated files take precedence when present
+  const derive = async (subPath: (r: Resolution) => string, payload: { data?: Tuple[]; series?: SeriesEntry[] }) => {
+    if (writtenPaths.has(subPath("daily"))) return; // an authoritative source file already wrote it
+    await writeHistory(subPath, generatedAt, "usd", payload);
+    stats.written += 3;
+    stats.derivedVolume = (stats.derivedVolume ?? 0) + 3;
+  };
+
+  for (const s of chainSeries) {
+    if (!s.slug || !s.data.length) continue;
+    await derive((r) => `history/volume/${r}/chain/${s.slug}/total`, { data: s.data });
+  }
+  for (const s of tokenSeries) {
+    if (!s.slug || !s.data.length) continue;
+    await derive((r) => `history/volume/${r}/asset/${s.slug}/total`, { data: s.data });
+  }
+  for (const [slug, series] of perAssetChainVolume) {
+    await derive((r) => `history/volume/${r}/asset/${slug}/by-chain`, { series });
+  }
+}

--- a/api2/v2/build.ts
+++ b/api2/v2/build.ts
@@ -13,7 +13,7 @@ import {
   chainSlugFromLabel,
   identitySeriesFields,
   pointsToTuples,
-  sampleTuples,
+  sampleByResolution,
   sumRecord,
   sumRecordOrNull,
 } from "./shared";
@@ -37,6 +37,18 @@ function sortDedupe(tuples: Tuple[]): Tuple[] {
 }
 
 let writtenPaths = new Set<string>();
+let dirsCreated = new Map<string, Promise<unknown>>();
+const ensureDir = (dir: string): Promise<unknown> => {
+  let created = dirsCreated.get(dir);
+  if (!created) {
+    created = fs.promises.mkdir(dir, { recursive: true }).catch((e) => {
+      dirsCreated.delete(dir);
+      throw e;
+    });
+    dirsCreated.set(dir, created);
+  }
+  return created;
+};
 
 const BR_MIN_BYTES = 1024;
 const brotli = (buf: Buffer): Promise<Buffer> =>
@@ -48,28 +60,25 @@ const brotli = (buf: Buffer): Promise<Buffer> =>
     )
   );
 
-async function writeAtomic(filePath: string, buf: Buffer) {
-  const tmp = filePath + ".tmp";
-  await fs.promises.writeFile(tmp, buf);
-  await fs.promises.rename(tmp, filePath);
-}
-
 async function writeV2(subPath: string, data: any) {
   const filePath = getRouteDataPath(`v2/${subPath}`);
-  await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+  await ensureDir(path.dirname(filePath));
   const buf = Buffer.from(JSON.stringify(data));
-  // .br is written/removed before the plain file is visible, so reads never see a mismatched pair
-  if (buf.length >= BR_MIN_BYTES) {
-    await writeAtomic(filePath + ".br", await brotli(buf));
+  const tmp = filePath + ".tmp";
+  const brWrite = buf.length >= BR_MIN_BYTES ? brotli(buf).then((out) => fs.promises.writeFile(filePath + ".br.tmp", out)) : null;
+  await Promise.all([fs.promises.writeFile(tmp, buf), brWrite]);
+  if (brWrite) {
+    await fs.promises.rename(filePath + ".br.tmp", filePath + ".br");
     writtenPaths.add(subPath + ".br");
   } else {
     await fs.promises.unlink(filePath + ".br").catch(() => {});
   }
-  await writeAtomic(filePath, buf);
+  await fs.promises.rename(tmp, filePath);
   writtenPaths.add(subPath);
 }
 
 const IO_CONCURRENCY = 8;
+const PARSE_CONCURRENCY = 3;
 async function mapPool<T, R>(items: T[], limit: number, fn: (item: T, index: number) => Promise<R>): Promise<R[]> {
   const out: R[] = new Array(items.length);
   let next = 0;
@@ -116,12 +125,13 @@ const exists = (filePath: string): Promise<boolean> =>
     .then(() => true)
     .catch(() => false);
 
-async function assertSourcesNotRegressed(chainLabels: string[], listed: [any, AssetInfo][]) {
+type PublishedBefore = { chains: Set<string>; assets: Set<string> };
+
+async function assertSourcesNotRegressed(chainLabels: string[], listed: [any, AssetInfo][]): Promise<PublishedBefore> {
   const lostChains = (
     await mapPool(chainLabels, IO_CONCURRENCY, async (label) => {
       const slug = chainSlugFromLabel(label);
       if (await exists(getRouteDataPath(`stablecoincharts2/${slug}`))) return null;
-      // no source now - was there an artifact from a previous build?
       return (await exists(getRouteDataPath(`v2/history/market-cap/daily/by-asset-chain/${slug}`))) ? slug : null;
     })
   ).filter(Boolean);
@@ -131,15 +141,42 @@ async function assertSourcesNotRegressed(chainLabels: string[], listed: [any, As
       return (await exists(getRouteDataPath(`v2/asset/${info.slug}`))) ? info.slug : null;
     })
   ).filter(Boolean);
-  if (!lostChains.length && !lostAssets.length) return;
-  const detail = `chains [${lostChains.join(", ") || "none"}], assets [${lostAssets.join(", ") || "none"}]`;
+  const publishedSlugs = async (dir: string) =>
+    (await fs.promises.readdir(getRouteDataPath(dir)).catch(() => [] as string[])).filter((f) => !f.endsWith(".br"));
+  const publishedChains = await publishedSlugs("v2/history/market-cap/daily/by-asset-chain");
+  const publishedAssets = await publishedSlugs("v2/asset");
+  const nowChains = new Set(chainLabels.map(chainSlugFromLabel));
+  const nowAssets = new Set(listed.map(([, info]) => info.slug));
+  const retiredChains = publishedChains.filter((s) => !nowChains.has(s));
+  const retiredAssets = publishedAssets.filter((s) => !nowAssets.has(s));
+
+  const droppedChains = nowChains.size < publishedChains.length ? retiredChains : [];
+  const droppedAssets = nowAssets.size < publishedAssets.length ? retiredAssets : [];
+  if (retiredChains.length || retiredAssets.length) {
+    console.error(
+      `v2 build: slugs retired since the last build - chains [${retiredChains.join(", ") || "none"}], ` +
+        `assets [${retiredAssets.join(", ") || "none"}]. Entity counts: chains ${publishedChains.length} -> ` +
+        `${nowChains.size}, assets ${publishedAssets.length} -> ${nowAssets.size}` +
+        (droppedChains.length || droppedAssets.length ? " - COUNT FELL, treating as source loss" : " (count held, treating as renames)")
+    );
+  }
+
+  // volume is deliberately unguarded: aborting on it would freeze market-cap and supply too,
+  // so a missing volume source is reported through `_manifest` instead
+  const published: PublishedBefore = { chains: new Set(publishedChains), assets: new Set(publishedAssets) };
+  const lost = lostChains.length + lostAssets.length + droppedChains.length + droppedAssets.length;
+  if (!lost) return published;
+  const detail =
+    `unreadable chains [${lostChains.join(", ") || "none"}], unreadable assets [${lostAssets.join(", ") || "none"}], ` +
+    `chains gone from the listing [${droppedChains.join(", ") || "none"}], ` +
+    `assets gone from the listing [${droppedAssets.join(", ") || "none"}]`;
   if (process.env.STABLECOINS_V2_ALLOW_SOURCE_REGRESSION === "1") {
     console.error(`v2 build: source regression accepted via STABLECOINS_V2_ALLOW_SOURCE_REGRESSION: ${detail}`);
-    return;
+    return published;
   }
   throw new Error(
-    `v2 build: ${lostChains.length + lostAssets.length} source(s) that previously published artifacts are now ` +
-      `unreadable - refusing to publish a build with holes in it: ${detail}. ` +
+    `v2 build: ${lost} source(s) that previously published artifacts are now ` +
+      `missing - refusing to publish a build with holes in it: ${detail}. ` +
       `The previous build is left intact and will be served until it ages out. If this is a genuine delisting, ` +
       `rerun once with STABLECOINS_V2_ALLOW_SOURCE_REGRESSION=1.`
   );
@@ -152,31 +189,49 @@ function sortSeries(series: SeriesEntry[]): SeriesEntry[] {
   return series.filter((s) => s.data.length).sort((a, b) => last(b) - last(a));
 }
 
-// writes {unit, data} or {unit, series} under every resolution
+// writes {unit, data} or {unit, series} at every resolution
 async function writeHistory(pathFor: (res: Resolution) => string, generatedAt: number, unit: string, payload: { data?: Tuple[]; series?: SeriesEntry[] }) {
-  await mapPool(RESOLUTIONS, RESOLUTIONS.length, async (res) => {
-    const out: any = { generatedAt, unit };
-    if (payload.data) out.data = sampleTuples(payload.data, res);
-    else out.series = sortSeries((payload.series ?? []).map((s) => ({ ...s, data: sampleTuples(s.data, res) })));
-    await writeV2(pathFor(res), out);
-  });
+  if (payload.data) {
+    const sampled = sampleByResolution(payload.data);
+    await mapPool(RESOLUTIONS, RESOLUTIONS.length, (res) => writeV2(pathFor(res), { generatedAt, unit, data: sampled[res] }));
+    return;
+  }
+  // sortSeries keys on each series' LAST point, and sampling moves neither: the last bucket's period-end point IS the last daily point, and a non-empty series can't sample down to empty.
+  const ordered = sortSeries(payload.series ?? []);
+  const sampled = ordered.map((s) => sampleByResolution(s.data));
+  await mapPool(RESOLUTIONS, RESOLUTIONS.length, (res) =>
+    writeV2(pathFor(res), {
+      generatedAt,
+      unit,
+      series: res === "daily" ? ordered : ordered.map((s, i) => ({ ...s, data: sampled[i][res] })),
+    })
+  );
 }
 
 export async function buildV2Files() {
   const generatedAt = Math.floor(Date.now() / 1e3);
   const reg = assetRegistry();
+  if (reg.issues.length) {
+    throw new Error(
+      `v2 build: ${reg.issues.length} unusable peggedData entries - refusing to publish: ${reg.issues.join("; ")}. ` +
+        `The previous build is left intact and will be served until it ages out; fix peggedData to unblock.`
+    );
+  }
   const stats = {
     written: 0,
     missingChainFiles: [] as string[],
     missingAssetFiles: [] as string[],
+    missingVolumeFiles: [] as string[],
+    volumeSources: 0,
     removed: 0,
     droppedPoints: 0,
     sweepSkipped: false,
     derivedVolume: 0,
   };
   writtenPaths = new Set<string>();
+  dirsCreated = new Map<string, Promise<unknown>>();
 
-  const [stablecoins, stablecoinChains, chartsAll, domFile, rates] = await Promise.all([
+  let [stablecoins, stablecoinChains, chartsAll, domFile, rates] = await Promise.all([
     readRouteData("stablecoins"),
     readRouteData("stablecoinchains"),
     readRouteData("stablecoincharts2/all"),
@@ -184,7 +239,7 @@ export async function buildV2Files() {
     readRouteData("rates"),
   ]);
 
-  // guard on content not key presence - an empty-but-present source would otherwise publish an empty dataset as healthy
+  // guard on content, not key presence - an empty-but-present source would publish as healthy
   const sourceAssets: any[] = Array.isArray(stablecoins?.peggedAssets) ? stablecoins.peggedAssets : [];
   const breakdownIds = chartsAll?.breakdown && typeof chartsAll.breakdown === "object" ? Object.keys(chartsAll.breakdown) : [];
   if (!sourceAssets.length) throw new Error("v2 build: /stablecoins has no peggedAssets - refusing to publish an empty dataset");
@@ -249,8 +304,8 @@ export async function buildV2Files() {
     listed.push([a, info]);
   }
 
-  // pre-flight: refuse to publish if sources regressed (skipping just the sweep isn't enough); only counts as regression if a previous build published that entity
-  await assertSourcesNotRegressed(chainLabels, listed);
+  // pre-flight: refuse to publish if a source that previously published artifacts is now unreadable
+  const publishedBefore = await assertSourcesNotRegressed(chainLabels, listed);
 
   await writeV2("assets", {
     generatedAt,
@@ -258,7 +313,7 @@ export async function buildV2Files() {
   });
   stats.written++;
 
-  for (const label of chainLabels) {
+  await mapPool(chainLabels, IO_CONCURRENCY, async (label) => {
     const scoped = listed
       .map(([a, info]) => {
         const chainScope = a.chainCirculating?.[label];
@@ -271,16 +326,15 @@ export async function buildV2Files() {
       assets: scoped.sort((x, y) => y.circulatingUsd - x.circulatingUsd),
     });
     stats.written++;
-  }
+  });
 
-  // chains snapshot: totals from /stablecoinchains, prev* from the per-chain series, dominant asset from dominanceMap
-  const chainChartMap = domFile?.chainChartMap ?? {};
-  const dominanceMap = domFile?.dominanceMap ?? {};
+  // chains snapshot: totals from /stablecoinchains, prev* from the per-chain series, dominant from dominanceMap
+  let chainChartMap = domFile?.chainChartMap ?? {};
+  let dominanceMap = domFile?.dominanceMap ?? {};
   const valueAtOffset = (tuples: Tuple[], last: number, offsetDays: number): number | null => {
     const target = last - offsetDays * 86400;
     let best: Tuple | null = null;
     for (const t of tuples) {
-      // closest record within 1.5 days, same tolerance class as v1 snapshot offsets
       if (Math.abs(t[0] - target) <= 86400 * 1.5 && (!best || Math.abs(t[0] - target) < Math.abs(best[0] - target))) best = t;
     }
     return best ? best[1] : null;
@@ -308,70 +362,92 @@ export async function buildV2Files() {
 
   // ---------- market-cap histories ----------
 
-  // global total excludes doublecounted (v1 aggregated does not - sum the clean series instead)
+  // global total excludes doublecounted, so it's summed from the clean series rather than v1's aggregate
   const globalByDate = new Map<number, number>();
   const assetSeriesGlobal: SeriesEntry[] = [];
+  const assetTotals: [AssetInfo, Tuple[]][] = [];
   for (const [id, points] of Object.entries(chartsAll.breakdown)) {
     const info = reg.byId.get(id);
     if (!info) continue;
     const tuples = pointsToTuples(points as any[], "totalCirculatingUSD");
     assetSeriesGlobal.push({ ...identitySeriesFields(info), data: tuples });
     if (!doubleIds.has(id)) for (const [ts, v] of tuples) globalByDate.set(ts, (globalByDate.get(ts) ?? 0) + v);
+    assetTotals.push([info, tuples]);
+  }
+  await mapPool(assetTotals, IO_CONCURRENCY, async ([info, tuples]) => {
     await writeHistory((r) => `history/market-cap/${r}/total-asset/${info.slug}`, generatedAt, "usd", { data: tuples });
     stats.written += 3;
-  }
+  });
+  chartsAll.breakdown = null;
+  assetTotals.length = 0;
   const globalTotal: Tuple[] = [...globalByDate.entries()].sort((a, b) => a[0] - b[0]).map(([t, v]) => [t, round(v)]);
+  globalByDate.clear();
   await writeHistory((r) => `history/market-cap/${r}/total`, generatedAt, "usd", { data: globalTotal });
   await writeHistory((r) => `history/market-cap/${r}/by-asset`, generatedAt, "usd", { series: assetSeriesGlobal });
   stats.written += 6;
+  assetSeriesGlobal.length = 0;
 
   const chainSeriesGlobal: SeriesEntry[] = Object.entries(chainChartMap).map(([label, points]) => ({
     slug: chainSlugFromLabel(label),
     name: label,
     data: pointsToTuples(points as any[], "totalCirculatingUSD"),
   }));
+  domFile = null;
+  chainChartMap = {};
+  dominanceMap = {};
   await writeHistory((r) => `history/market-cap/${r}/by-chain`, generatedAt, "usd", { series: chainSeriesGlobal });
   stats.written += 3;
-  for (const s of chainSeriesGlobal) {
+  await mapPool(chainSeriesGlobal, IO_CONCURRENCY, async (s) => {
     await writeHistory((r) => `history/market-cap/${r}/total-chain/${s.slug}`, generatedAt, "usd", { data: s.data });
     stats.written += 3;
-  }
+  });
+  chainSeriesGlobal.length = 0;
 
-  // per-chain asset breakdowns + per-asset chain breakdowns, one pass over the v1 chain files
+  // per-chain asset breakdowns + per-asset chain breakdowns in one pass over the v1 chain files
   const perAssetChains = new Map<string, SeriesEntry[]>();
-  for (const label of chainLabels) {
+  const chainResults = await mapPool(chainLabels, PARSE_CONCURRENCY, async (label) => {
     const chainSlug = chainSlugFromLabel(label);
     const chainFile = await readRouteData(`stablecoincharts2/${chainSlug}`);
-    if (!chainFile?.breakdown) {
-      stats.missingChainFiles.push(chainSlug);
-      continue;
-    }
+    if (!chainFile?.breakdown) return { chainSlug, perAsset: null };
     const series: SeriesEntry[] = [];
+    const perAsset: [string, SeriesEntry][] = [];
     for (const [id, points] of Object.entries(chainFile.breakdown)) {
       const info = reg.byId.get(id);
       if (!info) continue;
       const tuples = pointsToTuples(points as any[], "totalCirculatingUSD");
       if (!tuples.length) continue;
       series.push({ ...identitySeriesFields(info), data: tuples });
-      if (!perAssetChains.has(id)) perAssetChains.set(id, []);
-      perAssetChains.get(id)!.push({ slug: chainSlug, name: label, data: tuples });
+      perAsset.push([id, { slug: chainSlug, name: label, data: tuples }]);
     }
     await writeHistory((r) => `history/market-cap/${r}/by-asset-chain/${chainSlug}`, generatedAt, "usd", { series });
     stats.written += 3;
+    return { chainSlug, perAsset };
+  });
+  // folded back in chain-list order
+  for (const { chainSlug, perAsset } of chainResults) {
+    if (!perAsset) {
+      stats.missingChainFiles.push(chainSlug);
+      continue;
+    }
+    for (const [id, entry] of perAsset) {
+      if (!perAssetChains.has(id)) perAssetChains.set(id, []);
+      perAssetChains.get(id)!.push(entry);
+    }
   }
-  for (const [id, series] of perAssetChains) {
+  await mapPool([...perAssetChains], IO_CONCURRENCY, async ([id, series]) => {
     const info = reg.byId.get(id)!;
     await writeHistory((r) => `history/market-cap/${r}/by-chain-asset/${info.slug}`, generatedAt, "usd", { series });
     stats.written += 3;
-  }
+  });
+  perAssetChains.clear();
 
   // ---------- supply histories (raw token counts, from the v1 asset detail files) ----------
 
-  // one unit of work per asset; misses are collected and folded back afterwards for deterministic stats
-  const assetMisses = await mapPool(listed, IO_CONCURRENCY, async ([listedAsset, info]) => {
+  // one unit of work per asset; misses are folded back afterwards so stats stay deterministic
+  const assetMisses = await mapPool(listed, PARSE_CONCURRENCY, async ([listedAsset, info]) => {
     const detail = await readRouteData(`stablecoin/${info.id}`);
     if (!detail) return info.slug;
-    // both variants share one walk of the token array: they differ only by the unreleased addend
+    // both variants share one walk of the token array; they differ only by the unreleased addend
     const tuplesBoth = (tokens: any[]): { plain: Tuple[]; unreleased: Tuple[] } => {
       const plain: Tuple[] = [];
       const unreleased: Tuple[] = [];
@@ -401,10 +477,10 @@ export async function buildV2Files() {
     await writeHistory((r) => `history/supply/${r}/${info.slug}/by-chain-unreleased`, generatedAt, "count", { series: chainSeriesFor("unreleased") });
     stats.written += 4 * RESOLUTIONS.length;
 
-    // circulatingUsd must match /v2/assets' source or directory and detail pages disagree; only unpriced quantities are converted here
     const priceUsd = typeof detail.price === "number" ? detail.price : null;
     const refUsd = referenceUsdFor(info);
-    const price = priceUsd ?? refUsd ?? 0;
+    const price = priceUsd ?? refUsd;
+    const toUsd = (rec: any): number | null => (price === null ? null : round(sumRecord(rec) * price));
     const lastOf = (tokens: any[]) => (tokens?.length ? tokens[tokens.length - 1] : null);
     const chainsCurrent = Object.entries(detail.chainBalances ?? {})
       .map(([label, v]: [string, any]) => {
@@ -414,14 +490,14 @@ export async function buildV2Files() {
         return {
           slug: chainSlugFromLabel(label),
           name: label,
-          circulatingUsd: scope ? sumRecordOrNull(scope.current) ?? 0 : round(sumRecord(last.circulating) * price),
-          unreleasedUsd: round(sumRecord(last.unreleased) * price),
-          bridgedInUsd: round(sumRecord(last.bridgedTo) * price),
-          mintedUsd: round(sumRecord(last.minted) * price),
+          circulatingUsd: scope ? sumRecordOrNull(scope.current) ?? 0 : toUsd(last.circulating),
+          unreleasedUsd: toUsd(last.unreleased),
+          bridgedInUsd: toUsd(last.bridgedTo),
+          mintedUsd: toUsd(last.minted),
         };
       })
       .filter(Boolean)
-      .sort((a: any, b: any) => b.circulatingUsd - a.circulatingUsd);
+      .sort((a: any, b: any) => (b.circulatingUsd ?? -1) - (a.circulatingUsd ?? -1));
     const globalLast = lastOf(detail.tokens);
     const raw = info.raw;
     await writeV2(`asset/${info.slug}`, {
@@ -446,7 +522,7 @@ export async function buildV2Files() {
       auditLinks: raw.auditLinks ?? raw.audit_links ?? [],
       onCoinGecko: raw.onCoinGecko === "true" || raw.onCoinGecko === true,
       circulatingUsd: sumRecordOrNull(listedAsset.circulating) ?? 0,
-      unreleasedUsd: globalLast ? round(sumRecord(globalLast.unreleased) * price) : 0,
+      unreleasedUsd: globalLast ? toUsd(globalLast.unreleased) : 0,
       ...(info.doublecounted ? { doublecounted: true } : {}),
       ...(info.deprecated ? { deprecated: true } : {}),
       ...(info.delisted ? { delisted: true } : {}),
@@ -465,14 +541,28 @@ export async function buildV2Files() {
   // sweep only runs if no sources regressed vs the previous build - a missing source could be delisted or just unreadable, and deleting on the latter is catastrophic
   const prevMissingChains = typeof previousManifest?.missingChainSources === "number" ? previousManifest.missingChainSources : Infinity;
   const prevMissingAssets = typeof previousManifest?.missingAssetSources === "number" ? previousManifest.missingAssetSources : Infinity;
-  const degraded = stats.missingChainFiles.length > prevMissingChains || stats.missingAssetFiles.length > prevMissingAssets;
+  const unreadableChains = stats.missingChainFiles.filter((s) => publishedBefore.chains.has(s));
+  const unreadableAssets = stats.missingAssetFiles.filter((s) => publishedBefore.assets.has(s));
+  const degraded =
+    stats.missingChainFiles.length > prevMissingChains ||
+    stats.missingAssetFiles.length > prevMissingAssets ||
+    unreadableChains.length > 0 ||
+    unreadableAssets.length > 0;
   if (degraded) {
     stats.sweepSkipped = true;
     console.error(
       `v2 build: SOURCES REGRESSED (chains ${prevMissingChains} -> ${stats.missingChainFiles.length}, ` +
         `assets ${prevMissingAssets} -> ${stats.missingAssetFiles.length}) - skipping orphan sweep to avoid ` +
         `deleting still-good data. Missing chains: ${stats.missingChainFiles.join(", ") || "none"}; ` +
-        `missing assets: ${stats.missingAssetFiles.join(", ") || "none"}`
+        `missing assets: ${stats.missingAssetFiles.join(", ") || "none"}; ` +
+        `previously published but unreadable now: chains [${unreadableChains.join(", ") || "none"}], ` +
+        `assets [${unreadableAssets.join(", ") || "none"}]`
+    );
+  }
+  if (stats.missingVolumeFiles.length) {
+    console.error(
+      `v2 build: ${stats.missingVolumeFiles.length} volume source(s) unreadable - those routes will answer ` +
+        `data_unavailable until the next run: ${stats.missingVolumeFiles.join(", ")}`
     );
   }
   const removed = degraded ? [] : await sweepOrphans();
@@ -486,15 +576,25 @@ export async function buildV2Files() {
     chains: chainLabels.length,
     missingChainSources: stats.missingChainFiles.length,
     missingAssetSources: stats.missingAssetFiles.length,
+    missingVolumeSources: stats.missingVolumeFiles.length,
+    volumeSources: stats.volumeSources,
   });
 
   console.log(
     `v2 build done: ${stats.written} files, ${removed.length} orphans removed` +
       (stats.missingChainFiles.length ? `; missing chain sources: ${stats.missingChainFiles.length}` : "") +
-      (stats.missingAssetFiles.length ? `; missing asset sources: ${stats.missingAssetFiles.length}` : "")
+      (stats.missingAssetFiles.length ? `; missing asset sources: ${stats.missingAssetFiles.length}` : "") +
+      (stats.missingVolumeFiles.length ? `; missing volume sources: ${stats.missingVolumeFiles.length}` : "")
   );
   return stats;
 }
+
+const TOP_LEVEL_VOLUME = [
+  "chart-total",
+  "chart-total-chain-breakdown",
+  "chart-total-token-breakdown",
+  "chart-total-currency-breakdown",
+];
 
 async function buildVolume(generatedAt: number, reg: ReturnType<typeof assetRegistry>, stats: any) {
   const volumeDir = getRouteDataPath("volume");
@@ -502,11 +602,13 @@ async function buildVolume(generatedAt: number, reg: ReturnType<typeof assetRegi
   try {
     files = await fs.promises.readdir(volumeDir);
   } catch {
+    stats.missingVolumeFiles.push(...TOP_LEVEL_VOLUME);
     console.error("v2 build: no volume files found, skipping volume endpoints");
     return;
   }
-  // filter to names the v1 writer actually produces - a stray .tmp/.br file would leak into a route path
+  // drop stray .tmp/.br files - their names would leak into route paths
   files = files.filter((f) => !/\.(tmp|br)$/.test(f));
+  stats.volumeSources = files.length;
   const readVolume = (name: string) => readRouteData(`volume/${name}`);
 
   const totalTuples = (rows: any[]): Tuple[] => {
@@ -543,7 +645,7 @@ async function buildVolume(generatedAt: number, reg: ReturnType<typeof assetRegi
 
   const assetIdentity = (symbol: string) => {
     const matches = reg.bySymbol.get(symbol.toUpperCase()) ?? [];
-    // volume source data is keyed by token symbol; only a unique match gets asset identity
+    // volume sources are keyed by symbol; only a unique match earns an asset identity
     if (matches.length === 1) return { id: matches[0].id, slug: matches[0].slug, name: matches[0].name, symbol: matches[0].symbol };
     return { slug: null, name: symbol, symbol };
   };
@@ -552,7 +654,8 @@ async function buildVolume(generatedAt: number, reg: ReturnType<typeof assetRegi
     const name = sdk.chainUtils.getChainLabelFromKey(key);
     return { slug: chainSlugFromLabel(name), name };
   };
-  // slugs from volume filenames are label-slugs, not chain keys - resolve via chain list, not getChainLabelFromKey (mangles them, e.g. "op-mainnet" -> "Op-mainnet")
+  // volume filenames carry label-slugs, not chain keys, so resolve via the chain list:
+  // getChainLabelFromKey mangles them (e.g. "op-mainnet" -> "Op-mainnet")
   const labelBySlug = new Map<string, string>();
   for (const label of Object.values(sdk.chainUtils.chainKeyToChainLabelMap ?? {}) as string[]) {
     if (label) labelBySlug.set(chainSlugFromLabel(label), label);
@@ -566,13 +669,14 @@ async function buildVolume(generatedAt: number, reg: ReturnType<typeof assetRegi
     stats.written += 3;
   };
 
-  const [totalRows, chainBreakdown, tokenBreakdown, currencyBreakdown] = await Promise.all([
-    readVolume("chart-total"),
-    readVolume("chart-total-chain-breakdown"),
-    readVolume("chart-total-token-breakdown"),
-    readVolume("chart-total-currency-breakdown"),
-  ]);
-  // each breakdown is pivoted once, reused by its own endpoint and the derived families below
+  const [totalRows, chainBreakdown, tokenBreakdown, currencyBreakdown] = await Promise.all(
+    TOP_LEVEL_VOLUME.map(readVolume)
+  );
+  // readRouteData nulls both unreadable and deleted sources - count either rather than skip silently
+  for (const [i, rows] of [totalRows, chainBreakdown, tokenBreakdown, currencyBreakdown].entries()) {
+    if (!rows) stats.missingVolumeFiles.push(TOP_LEVEL_VOLUME[i]);
+  }
+  // pivoted once, reused by its own endpoint and the derived families below
   const chainSeries = chainBreakdown ? breakdownSeries(chainBreakdown, chainIdentity) : [];
   const tokenSeries = tokenBreakdown ? breakdownSeries(tokenBreakdown, assetIdentity) : [];
   if (totalRows) await writeIf(totalRows, (r) => `history/volume/${r}/total`, { data: totalTuples(totalRows) });
@@ -580,10 +684,10 @@ async function buildVolume(generatedAt: number, reg: ReturnType<typeof assetRegi
   if (tokenBreakdown) await writeIf(tokenBreakdown, (r) => `history/volume/${r}/by-asset`, { series: tokenSeries });
   if (currencyBreakdown) await writeIf(currencyBreakdown, (r) => `history/volume/${r}/by-pegcurrency`, { series: breakdownSeries(currencyBreakdown, currencyIdentity) });
 
-  // asset -> per-chain volume series, pivoted out of the per-chain token breakdowns below
+  // asset -> per-chain volume, pivoted out of the per-chain token breakdowns below
   const perAssetChainVolume = new Map<string, SeriesEntry[]>();
 
-  for (const file of files) {
+  const fileResults = await mapPool(files, PARSE_CONCURRENCY, async (file) => {
     if (file.startsWith("chart-chain-")) {
       const rest = file.slice("chart-chain-".length);
       if (rest.endsWith("-token-breakdown")) {
@@ -591,11 +695,9 @@ async function buildVolume(generatedAt: number, reg: ReturnType<typeof assetRegi
         const rows = await readVolume(file);
         const series = breakdownSeries(rows, assetIdentity);
         await writeIf(rows, (r) => `history/volume/${r}/chain/${chainSlug}/by-asset`, { series });
-        for (const s of series) {
-          if (!s.slug || !s.data.length) continue; // ambiguous symbol: not attributable to one asset
-          if (!perAssetChainVolume.has(s.slug)) perAssetChainVolume.set(s.slug, []);
-          perAssetChainVolume.get(s.slug)!.push({ ...chainIdentityFromSlug(chainSlug), data: s.data });
-        }
+        return series
+          .filter((s) => s.slug && s.data.length)
+          .map((s): [string, SeriesEntry] => [s.slug, { ...chainIdentityFromSlug(chainSlug), data: s.data }]);
       } else if (rest.endsWith("-currency-breakdown")) {
         const chainSlug = rest.slice(0, -"-currency-breakdown".length);
         const rows = await readVolume(file);
@@ -609,31 +711,45 @@ async function buildVolume(generatedAt: number, reg: ReturnType<typeof assetRegi
       const isChainBreakdown = rest.endsWith("-chain-breakdown");
       const symbol = isChainBreakdown ? rest.slice(0, -"-chain-breakdown".length) : rest;
       const matches = reg.bySymbol.get(symbol.toUpperCase()) ?? [];
-      if (matches.length !== 1) continue; // ambiguous or unknown symbol: not routable by asset slug
+      if (matches.length !== 1) return null;
       const slug = matches[0].slug;
       const rows = await readVolume(file);
       if (isChainBreakdown) await writeIf(rows, (r) => `history/volume/${r}/asset/${slug}/by-chain`, { series: breakdownSeries(rows, chainIdentity) });
       else await writeIf(rows, (r) => `history/volume/${r}/asset/${slug}/total`, { data: totalTuples(rows) });
     }
+    return null;
+  });
+  for (const entries of fileResults) {
+    for (const [slug, entry] of entries ?? []) {
+      if (!perAssetChainVolume.has(slug)) perAssetChainVolume.set(slug, []);
+      perAssetChainVolume.get(slug)!.push(entry);
+    }
   }
 
-  // derives routes with no dedicated v1 source file from the breakdowns above; dedicated files take precedence when present
-  const derive = async (subPath: (r: Resolution) => string, payload: { data?: Tuple[]; series?: SeriesEntry[] }) => {
-    if (writtenPaths.has(subPath("daily"))) return; // an authoritative source file already wrote it
-    await writeHistory(subPath, generatedAt, "usd", payload);
-    stats.written += 3;
-    stats.derivedVolume = (stats.derivedVolume ?? 0) + 3;
+  type Derived = [(r: Resolution) => string, { data?: Tuple[]; series?: SeriesEntry[] }];
+  const pending: Derived[] = [];
+  const queued = new Set<string>();
+  const derive = (subPath: (r: Resolution) => string, payload: Derived[1]) => {
+    const daily = subPath("daily");
+    if (writtenPaths.has(daily) || queued.has(daily)) return; // a dedicated source file already wrote it
+    queued.add(daily);
+    pending.push([subPath, payload]);
   };
 
   for (const s of chainSeries) {
     if (!s.slug || !s.data.length) continue;
-    await derive((r) => `history/volume/${r}/chain/${s.slug}/total`, { data: s.data });
+    derive((r) => `history/volume/${r}/chain/${s.slug}/total`, { data: s.data });
   }
   for (const s of tokenSeries) {
     if (!s.slug || !s.data.length) continue;
-    await derive((r) => `history/volume/${r}/asset/${s.slug}/total`, { data: s.data });
+    derive((r) => `history/volume/${r}/asset/${s.slug}/total`, { data: s.data });
   }
   for (const [slug, series] of perAssetChainVolume) {
-    await derive((r) => `history/volume/${r}/asset/${slug}/by-chain`, { series });
+    derive((r) => `history/volume/${r}/asset/${slug}/by-chain`, { series });
   }
+  await mapPool(pending, IO_CONCURRENCY, async ([subPath, payload]) => {
+    await writeHistory(subPath, generatedAt, "usd", payload);
+    stats.written += 3;
+    stats.derivedVolume = (stats.derivedVolume ?? 0) + 3;
+  });
 }

--- a/api2/v2/routes.ts
+++ b/api2/v2/routes.ts
@@ -2,12 +2,11 @@ import * as HyperExpress from "hyper-express";
 import { Resolution, assetRegistry, sliceTuples } from "./shared";
 import {
   Gate,
-  V2_MAX_AGE,
-  V2_STALE_AFTER,
   buildGate,
-  loadManifest,
+  checkedEpoch,
   loadV2File,
   parsedOf,
+  sendV2Empty,
   sendV2Entry,
   sendV2Error,
   sendV2Redirect,
@@ -76,7 +75,7 @@ function validate(req: HyperExpress.Request, res: HyperExpress.Response, metric:
     return;
   }
 
-  // canonicalize: lowercase slugs, fixed order, defaults elided -> one CDN entry per resource
+  // canonicalize - lowercase slugs, fixed order, defaults elided: one CDN entry per resource
   const canonical: Query = {};
   for (const key of PARAM_ORDER) {
     if (query[key] === undefined) continue;
@@ -88,8 +87,10 @@ function validate(req: HyperExpress.Request, res: HyperExpress.Response, metric:
         return;
       }
     }
+    if (key === "start" || key === "end") value = String(Number(value));
     if (key === "resolution" && value === "daily") continue;
     if (key === "includeUnreleased" && value === "false") continue;
+    if (key === "start" && value === "0") continue;
     canonical[key] = value;
   }
   const canonicalQs = Object.entries(canonical)
@@ -110,19 +111,25 @@ function resolveAsset(res: HyperExpress.Response, slug: string) {
   return info;
 }
 
-// chain identity: union of the `chains` snapshot and market-cap per-chain files; cached per build epoch
+// known chains: the `chains` snapshot plus per-chain market-cap files; cached per build epoch
 let chainSlugCache: { epoch: number; slugs: Set<string> } | null = null;
 async function knownChains(gate: Gate): Promise<Set<string>> {
   if (chainSlugCache?.epoch === gate.manifest.generatedAt) return chainSlugCache.slugs;
   const entry = await loadV2File("chains");
   const slugs = new Set<string>();
-  if (entry) for (const c of parsedOf(entry).chains ?? []) if (c?.slug) slugs.add(c.slug);
+  if (entry) {
+    try {
+      for (const c of parsedOf(entry).chains ?? []) if (c?.slug) slugs.add(c.slug);
+    } catch {}
+  }
   chainSlugCache = { epoch: gate.manifest.generatedAt, slugs };
   return slugs;
 }
 async function chainExists(slug: string, gate: Gate): Promise<boolean> {
   if ((await knownChains(gate)).has(slug)) return true;
-  return (await loadV2File(`history/market-cap/daily/total-chain/${slug}`)) !== null;
+  if ((await loadV2File(`history/market-cap/daily/total-chain/${slug}`)) !== null) return true;
+
+  return (await loadV2File(`history/volume/daily/chain/${slug}/total`)) !== null;
 }
 
 async function serveHistory(
@@ -134,9 +141,17 @@ async function serveHistory(
 ) {
   const entry = await loadV2File(filePath);
   if (!entry) {
-    // scope was validated so the entity exists
-    return sendV2Error(res, 503, "data_unavailable", `the last build did not produce data for this request (${filePath})`);
+    if (!query.asset && !query.chain) {
+      console.error(`v2: no artifact for an unscoped request: ${filePath}`);
+      return sendV2Error(res, 503, "data_unavailable", "data is temporarily unavailable");
+    }
+    const grouped = query.groupBy !== undefined && extractChainSlug === undefined;
+    const empty = grouped
+      ? { generatedAt: gate.manifest.generatedAt, unit, series: [] }
+      : { generatedAt: gate.manifest.generatedAt, unit, data: [] };
+    return sendV2Empty(req, res, `${filePath}|empty`, "history", gate, empty);
   }
+  if (checkedEpoch(res, entry, gate) === undefined) return;
   const start = query.start !== undefined ? Number(query.start) : undefined;
   const end = query.end !== undefined ? Number(query.end) : undefined;
 
@@ -144,7 +159,7 @@ async function serveHistory(
     return sendV2Entry(req, res, entry, "history", gate);
   }
 
-  // unknown chain must 404, not return empty
+  // an unknown chain must 404
   if (extractChainSlug !== undefined && !(parsedOf(entry).series ?? []).some((s: any) => s.slug === extractChainSlug)) {
     if (!(await chainExists(extractChainSlug, gate))) return sendV2Error(res, 404, "not_found", `unknown chain "${extractChainSlug}"`);
   }
@@ -175,7 +190,7 @@ export function setV2Routes(router: HyperExpress.Router) {
     const entry = await loadV2File(file);
     if (!entry) {
       if (query.chain) return sendV2Error(res, 404, "not_found", `unknown chain "${query.chain}"`);
-      return sendV2Error(res, 503, "data_unavailable", "the last build did not produce the asset snapshot");
+      return sendV2Error(res, 503, "data_unavailable", "data is temporarily unavailable");
     }
 
     return sendV2Entry(req, res, entry, "current", gate);
@@ -184,7 +199,12 @@ export function setV2Routes(router: HyperExpress.Router) {
   router.get("/v2/assets/:asset", v2Wrapper(async (req: any, res: any) => {
     if (Object.keys(req.query ?? {}).length) return sendV2Error(res, 400, "unknown_param", "this endpoint takes no query parameters");
 
-    const rawSlug = decodeURIComponent(req.path_parameters.asset);
+    let rawSlug: string;
+    try {
+      rawSlug = decodeURIComponent(req.path_parameters.asset);
+    } catch {
+      return sendV2Error(res, 400, "invalid_param", "asset is not a valid slug");
+    }
     const slug = rawSlug.toLowerCase();
     if (slug !== rawSlug) return sendV2Redirect(res, `/v2/assets/${encodeURIComponent(slug)}`);
 
@@ -194,8 +214,8 @@ export function setV2Routes(router: HyperExpress.Router) {
     if (!gate) return;
 
     const entry = await loadV2File(`asset/${info.slug}`);
-    // the asset is in the registry
-    if (!entry) return sendV2Error(res, 503, "data_unavailable", `the last build did not produce data for asset "${slug}"`);
+    // the registry has the asset, so only the build's file is missing
+    if (!entry) return sendV2Error(res, 503, "data_unavailable", "data is temporarily unavailable");
 
     return sendV2Entry(req, res, entry, "current", gate);
   }));
@@ -206,7 +226,7 @@ export function setV2Routes(router: HyperExpress.Router) {
     if (!gate) return;
 
     const entry = await loadV2File("chains");
-    if (!entry) return sendV2Error(res, 503, "data_unavailable", "the last build did not produce the chains snapshot");
+    if (!entry) return sendV2Error(res, 503, "data_unavailable", "data is temporarily unavailable");
 
     return sendV2Entry(req, res, entry, "current", gate);
   }));

--- a/api2/v2/routes.ts
+++ b/api2/v2/routes.ts
@@ -1,0 +1,303 @@
+import * as HyperExpress from "hyper-express";
+import { Resolution, assetRegistry, sliceTuples } from "./shared";
+import {
+  Gate,
+  V2_MAX_AGE,
+  V2_STALE_AFTER,
+  buildGate,
+  loadManifest,
+  loadV2File,
+  parsedOf,
+  sendV2Entry,
+  sendV2Error,
+  sendV2Redirect,
+  sendV2Sliced,
+  v2Wrapper,
+} from "./serve";
+
+const MAX_SAFE = 9007199254740991; // 2^53 - 1
+const GROUP_BY: Record<string, string[]> = {
+  "market-cap": ["asset", "chain"],
+  volume: ["asset", "chain", "pegCurrency"],
+  supply: ["chain"],
+};
+const PARAM_ORDER = ["asset", "chain", "groupBy", "includeUnreleased", "resolution", "start", "end"];
+const SAFE_SLUG = /^[a-z0-9][a-z0-9._+()-]*$/;
+
+type Query = { [key: string]: string };
+
+function validate(req: HyperExpress.Request, res: HyperExpress.Response, metric: string, allowed: string[]): Query | undefined {
+  const query: Query = {};
+  for (const [key, value] of Object.entries(req.query ?? {})) {
+    if (!allowed.includes(key)) {
+      sendV2Error(res, 400, "unknown_param", `unknown parameter "${key}"`);
+      return;
+    }
+    if (Array.isArray(value)) {
+      sendV2Error(res, 400, "invalid_param", `parameter "${key}" given more than once`);
+      return;
+    }
+    query[key] = String(value);
+  }
+
+  if (metric === "supply" && !query.asset) {
+    sendV2Error(res, 400, "missing_param", "supply requires an asset parameter");
+    return;
+  }
+  if (query.groupBy !== undefined && !GROUP_BY[metric]?.includes(query.groupBy)) {
+    sendV2Error(res, 400, "invalid_param", `groupBy must be one of: ${GROUP_BY[metric].join(", ")}`);
+    return;
+  }
+  if ((query.groupBy === "asset" && query.asset) || (query.groupBy === "chain" && query.chain)) {
+    sendV2Error(res, 400, "invalid_combination", `cannot scope and group by ${query.groupBy}`);
+    return;
+  }
+  if (metric === "volume" && query.groupBy === "pegCurrency" && query.asset) {
+    sendV2Error(res, 400, "invalid_combination", "asset scope with groupBy=pegCurrency is not supported (an asset has a single peg currency)");
+    return;
+  }
+  for (const key of ["start", "end"]) {
+    if (query[key] === undefined) continue;
+    if (!/^\d+$/.test(query[key]) || Number(query[key]) > MAX_SAFE) {
+      sendV2Error(res, 400, "invalid_param", `${key} must be a Unix-seconds integer`);
+      return;
+    }
+  }
+  if (query.start !== undefined && query.end !== undefined && Number(query.start) > Number(query.end)) {
+    sendV2Error(res, 400, "invalid_range", "start must be <= end");
+    return;
+  }
+  if (query.resolution !== undefined && !["daily", "weekly", "monthly"].includes(query.resolution)) {
+    sendV2Error(res, 400, "invalid_param", "resolution must be daily, weekly or monthly");
+    return;
+  }
+  if (query.includeUnreleased !== undefined && !["true", "false"].includes(query.includeUnreleased)) {
+    sendV2Error(res, 400, "invalid_param", "includeUnreleased must be true or false");
+    return;
+  }
+
+  // canonicalize: lowercase slugs, fixed order, defaults elided -> one CDN entry per resource
+  const canonical: Query = {};
+  for (const key of PARAM_ORDER) {
+    if (query[key] === undefined) continue;
+    let value = query[key];
+    if (key === "asset" || key === "chain") {
+      value = value.toLowerCase();
+      if (!SAFE_SLUG.test(value)) {
+        sendV2Error(res, 400, "invalid_param", `${key} is not a valid slug`);
+        return;
+      }
+    }
+    if (key === "resolution" && value === "daily") continue;
+    if (key === "includeUnreleased" && value === "false") continue;
+    canonical[key] = value;
+  }
+  const canonicalQs = Object.entries(canonical)
+    .map(([k, v]) => `${k}=${encodeURIComponent(v)}`)
+    .join("&");
+  const rawQs = req.url.includes("?") ? req.url.slice(req.url.indexOf("?") + 1) : "";
+  if (rawQs !== canonicalQs) {
+    sendV2Redirect(res, req.path + (canonicalQs ? `?${canonicalQs}` : ""));
+    return;
+  }
+  return canonical;
+}
+
+// resolves an asset slug; responds 404 and returns undefined when unknown
+function resolveAsset(res: HyperExpress.Response, slug: string) {
+  const info = assetRegistry().bySlug.get(slug);
+  if (!info) sendV2Error(res, 404, "not_found", `unknown asset "${slug}"`);
+  return info;
+}
+
+// chain identity: union of the `chains` snapshot and market-cap per-chain files; cached per build epoch
+let chainSlugCache: { epoch: number; slugs: Set<string> } | null = null;
+async function knownChains(gate: Gate): Promise<Set<string>> {
+  if (chainSlugCache?.epoch === gate.manifest.generatedAt) return chainSlugCache.slugs;
+  const entry = await loadV2File("chains");
+  const slugs = new Set<string>();
+  if (entry) for (const c of parsedOf(entry).chains ?? []) if (c?.slug) slugs.add(c.slug);
+  chainSlugCache = { epoch: gate.manifest.generatedAt, slugs };
+  return slugs;
+}
+async function chainExists(slug: string, gate: Gate): Promise<boolean> {
+  if ((await knownChains(gate)).has(slug)) return true;
+  return (await loadV2File(`history/market-cap/daily/total-chain/${slug}`)) !== null;
+}
+
+async function serveHistory(
+  req: HyperExpress.Request,
+  res: HyperExpress.Response,
+  filePath: string,
+  query: Query,
+  { extractChainSlug, unit, gate }: { extractChainSlug?: string; unit: string; gate: Gate }
+) {
+  const entry = await loadV2File(filePath);
+  if (!entry) {
+    // scope was validated so the entity exists
+    return sendV2Error(res, 503, "data_unavailable", `the last build did not produce data for this request (${filePath})`);
+  }
+  const start = query.start !== undefined ? Number(query.start) : undefined;
+  const end = query.end !== undefined ? Number(query.end) : undefined;
+
+  if (extractChainSlug === undefined && start === undefined && end === undefined) {
+    return sendV2Entry(req, res, entry, "history", gate);
+  }
+
+  // unknown chain must 404, not return empty
+  if (extractChainSlug !== undefined && !(parsedOf(entry).series ?? []).some((s: any) => s.slug === extractChainSlug)) {
+    if (!(await chainExists(extractChainSlug, gate))) return sendV2Error(res, 404, "not_found", `unknown chain "${extractChainSlug}"`);
+  }
+
+  const discriminator = `${filePath}|${extractChainSlug ?? ""}|${start ?? ""}|${end ?? ""}|${unit}`;
+  return sendV2Sliced(req, res, entry, discriminator, "history", gate, (epoch) => {
+    const parsed = parsedOf(entry);
+    const outUnit = parsed.unit ?? unit;
+    if (extractChainSlug !== undefined) {
+      const series = (parsed.series ?? []).find((s: any) => s.slug === extractChainSlug);
+      return { generatedAt: epoch, unit: outUnit, data: series ? sliceTuples(series.data, start, end) : [] };
+    }
+    if (parsed.data) return { generatedAt: epoch, unit: outUnit, data: sliceTuples(parsed.data, start, end) };
+    return { generatedAt: epoch, unit: outUnit, series: (parsed.series ?? []).map((s: any) => ({ ...s, data: sliceTuples(s.data, start, end) })) };
+  });
+}
+
+export function setV2Routes(router: HyperExpress.Router) {
+  const resolutionOf = (query: Query): Resolution => (query.resolution as Resolution) ?? "daily";
+
+  router.get("/v2/assets", v2Wrapper(async (req: any, res: any) => {
+    const query = validate(req, res, "assets", ["chain"]);
+    if (!query) return;
+    const gate = await buildGate(res);
+    if (!gate) return;
+
+    const file = query.chain ? `assets-chain/${query.chain}` : "assets";
+    const entry = await loadV2File(file);
+    if (!entry) {
+      if (query.chain) return sendV2Error(res, 404, "not_found", `unknown chain "${query.chain}"`);
+      return sendV2Error(res, 503, "data_unavailable", "the last build did not produce the asset snapshot");
+    }
+
+    return sendV2Entry(req, res, entry, "current", gate);
+  }));
+
+  router.get("/v2/assets/:asset", v2Wrapper(async (req: any, res: any) => {
+    if (Object.keys(req.query ?? {}).length) return sendV2Error(res, 400, "unknown_param", "this endpoint takes no query parameters");
+
+    const rawSlug = decodeURIComponent(req.path_parameters.asset);
+    const slug = rawSlug.toLowerCase();
+    if (slug !== rawSlug) return sendV2Redirect(res, `/v2/assets/${encodeURIComponent(slug)}`);
+
+    const info = resolveAsset(res, slug);
+    if (!info) return;
+    const gate = await buildGate(res);
+    if (!gate) return;
+
+    const entry = await loadV2File(`asset/${info.slug}`);
+    // the asset is in the registry
+    if (!entry) return sendV2Error(res, 503, "data_unavailable", `the last build did not produce data for asset "${slug}"`);
+
+    return sendV2Entry(req, res, entry, "current", gate);
+  }));
+
+  router.get("/v2/chains", v2Wrapper(async (req: any, res: any) => {
+    if (Object.keys(req.query ?? {}).length) return sendV2Error(res, 400, "unknown_param", "this endpoint takes no query parameters");
+    const gate = await buildGate(res);
+    if (!gate) return;
+
+    const entry = await loadV2File("chains");
+    if (!entry) return sendV2Error(res, 503, "data_unavailable", "the last build did not produce the chains snapshot");
+
+    return sendV2Entry(req, res, entry, "current", gate);
+  }));
+
+  router.get("/v2/history/market-cap", v2Wrapper(async (req: any, res: any) => {
+    const query = validate(req, res, "market-cap", ["asset", "chain", "groupBy", "start", "end", "resolution"]);
+    if (!query) return;
+    const gate = await buildGate(res);
+    if (!gate) return;
+
+    const res_ = resolutionOf(query);
+    if (query.asset && !resolveAsset(res, query.asset)) return;
+
+    const base = `history/market-cap/${res_}`;
+    if (query.chain && !(await chainExists(query.chain, gate))) return sendV2Error(res, 404, "not_found", `unknown chain "${query.chain}"`);
+
+    if (query.groupBy === "asset") {
+      return serveHistory(req, res, query.chain ? `${base}/by-asset-chain/${query.chain}` : `${base}/by-asset`, query, { unit: "usd", gate });
+    }
+
+    if (query.groupBy === "chain") {
+      const file = query.asset ? `${base}/by-chain-asset/${query.asset}` : `${base}/by-chain`;
+      return serveHistory(req, res, file, query, { unit: "usd", gate });
+    }
+
+    if (query.asset && query.chain) {
+      return serveHistory(req, res, `${base}/by-chain-asset/${query.asset}`, query, { extractChainSlug: query.chain, unit: "usd", gate });
+    }
+
+    if (query.asset) return serveHistory(req, res, `${base}/total-asset/${query.asset}`, query, { unit: "usd", gate });
+
+    if (query.chain) return serveHistory(req, res, `${base}/total-chain/${query.chain}`, query, { unit: "usd", gate });
+
+    return serveHistory(req, res, `${base}/total`, query, { unit: "usd", gate });
+  }));
+
+  router.get("/v2/history/volume", v2Wrapper(async (req: any, res: any) => {
+    const query = validate(req, res, "volume", ["asset", "chain", "groupBy", "start", "end", "resolution"]);
+    if (!query) return;
+    const gate = await buildGate(res);
+    if (!gate) return;
+
+    const res_ = resolutionOf(query);
+    if (query.asset && !resolveAsset(res, query.asset)) return;
+
+    if (query.chain && !(await chainExists(query.chain, gate))) return sendV2Error(res, 404, "not_found", `unknown chain "${query.chain}"`);
+
+    const base = `history/volume/${res_}`;
+    if (query.groupBy === "pegCurrency") {
+      const file = query.chain ? `${base}/chain/${query.chain}/by-pegcurrency` : `${base}/by-pegcurrency`;
+      return serveHistory(req, res, file, query, { unit: "usd", gate });
+    }
+
+    if (query.groupBy === "asset") {
+      const file = query.chain ? `${base}/chain/${query.chain}/by-asset` : `${base}/by-asset`;
+      return serveHistory(req, res, file, query, { unit: "usd", gate });
+    }
+
+    if (query.groupBy === "chain") {
+      const file = query.asset ? `${base}/asset/${query.asset}/by-chain` : `${base}/by-chain`;
+      return serveHistory(req, res, file, query, { unit: "usd", gate });
+    }
+
+    if (query.asset && query.chain) {
+      return serveHistory(req, res, `${base}/asset/${query.asset}/by-chain`, query, { extractChainSlug: query.chain, unit: "usd", gate });
+    }
+
+    if (query.asset) return serveHistory(req, res, `${base}/asset/${query.asset}/total`, query, { unit: "usd", gate });
+
+    if (query.chain) return serveHistory(req, res, `${base}/chain/${query.chain}/total`, query, { unit: "usd", gate });
+
+    return serveHistory(req, res, `${base}/total`, query, { unit: "usd", gate });
+  }));
+
+  router.get("/v2/history/supply", v2Wrapper(async (req: any, res: any) => {
+    const query = validate(req, res, "supply", ["asset", "chain", "groupBy", "includeUnreleased", "start", "end", "resolution"]);
+    if (!query) return;
+    const gate = await buildGate(res);
+    if (!gate) return;
+
+    const res_ = resolutionOf(query);
+    const info = resolveAsset(res, query.asset);
+    if (!info) return;
+
+    const suffix = query.includeUnreleased === "true" ? "-unreleased" : "";
+    const base = `history/supply/${res_}/${info.slug}`;
+
+    if (query.groupBy === "chain") return serveHistory(req, res, `${base}/by-chain${suffix}`, query, { unit: "count", gate });
+
+    if (query.chain) return serveHistory(req, res, `${base}/by-chain${suffix}`, query, { extractChainSlug: query.chain, unit: "count", gate });
+
+    return serveHistory(req, res, `${base}/total${suffix}`, query, { unit: "count", gate });
+  }));
+}

--- a/api2/v2/serve.ts
+++ b/api2/v2/serve.ts
@@ -43,7 +43,7 @@ function evict() {
   }
 }
 
-// dedupes concurrent misses on the same file - avoids a post-cron stampede re-reading the same buffer
+// dedupes concurrent misses on one file - avoids a post-cron stampede re-reading the same buffer
 const inflight = new Map<string, Promise<Entry | null>>();
 
 export async function loadV2File(subPath: string): Promise<Entry | null> {
@@ -67,44 +67,33 @@ export async function loadV2File(subPath: string): Promise<Entry | null> {
   return pending;
 }
 
-// decompresses only until `bytes` of output exist, so checking a sibling costs one chunk, not a full inflate
-function inflateHead(buf: Buffer, bytes: number): Promise<string> {
+function brotliMatches(br: Buffer, digest: string): Promise<boolean> {
   return new Promise((resolve) => {
     const stream = zlib.createBrotliDecompress();
-    let out = "";
-    let settled = false;
-    const finish = () => {
-      if (settled) return;
-      settled = true;
-      stream.destroy();
-      resolve(out);
-    };
-    stream.on("data", (chunk: Buffer) => {
-      out += chunk.toString("utf8");
-      if (out.length >= bytes) finish();
-    });
-    stream.on("end", finish);
-    stream.on("error", finish);
-    stream.end(buf);
+    const hash = crypto.createHash("md5");
+    stream.on("data", (chunk: Buffer) => hash.update(chunk));
+    stream.on("end", () => resolve(hash.digest("hex") === digest));
+    stream.on("error", () => resolve(false));
+    stream.end(br);
   });
 }
 
 async function readEntry(subPath: string, filePath: string): Promise<Entry | null> {
-  // read both files then re-stat both - if either moved, we may have mixed two builds and must retry
+  // read both, then re-stat both: if either moved, the pair may straddle two builds - retry
   for (let attempt = 0; attempt < 3; attempt++) {
     const [m0, b0] = await Promise.all([mtimeOf(filePath), mtimeOf(filePath + ".br")]);
     if (m0 === undefined) return null;
     const [buf, brRead] = await Promise.all([
       fs.promises.readFile(filePath),
-      // absent/unreadable .br just means "send it raw"
+      // an absent or unreadable .br just means "send it raw"
       b0 === undefined ? Promise.resolve(undefined) : fs.promises.readFile(filePath + ".br").catch(() => undefined),
     ]);
     const [m1, b1] = await Promise.all([mtimeOf(filePath), mtimeOf(filePath + ".br")]);
     if (m1 !== m0 || b1 !== b0) continue;
 
-    // sibling accepted only if it decompresses to the same build epoch - else a compressed client could get another build's bytes under this ETag
-    const epoch = epochOfHead(buf.subarray(0, 200).toString("utf8"));
-    const br = brRead && epoch !== undefined && epochOfHead(await inflateHead(brRead, 200)) === epoch ? brRead : undefined;
+    // byte-identity also settles the epoch: a sibling left over from another run cannot match
+    const digest = crypto.createHash("md5").update(buf).digest("hex");
+    const br = brRead && (await brotliMatches(brRead, digest)) ? brRead : undefined;
     const entry: Entry = {
       key: subPath,
       mtimeMs: m0,
@@ -112,7 +101,7 @@ async function readEntry(subPath: string, filePath: string): Promise<Entry | nul
       buf,
       br,
       bytes: buf.length + (br?.length ?? 0),
-      etag: '"' + crypto.createHash("md5").update(buf).digest("hex") + '"',
+      etag: '"' + digest + '"',
     };
     retain(entry);
     return entry;
@@ -124,15 +113,17 @@ export function parsedOf(entry: Entry): any {
   if (entry.parsed === undefined) {
     entry.parsed = JSON.parse(entry.buf.toString("utf8"));
     if (lru.get(entry.key) === entry) {
-      entry.bytes += entry.buf.length;
-      lruBytes += entry.buf.length;
+      const cost = entry.buf.length * 4;
+      entry.bytes += cost;
+      lruBytes += cost;
       evict();
     }
   }
   return entry.parsed;
 }
 
-// build freshness: answerable only when a completed build exists, isn't past the age ceiling, and the file's epoch matches `_manifest`'s
+// freshness: serve only when a completed build exists, is within the age ceiling, and the file's
+// epoch matches `_manifest`'s
 
 // mark responses stale past this age; refuse to serve past the ceiling
 export const V2_STALE_AFTER = num(process.env.STABLECOINS_V2_STALE_AFTER, 3 * 3600);
@@ -154,7 +145,7 @@ export async function loadManifest(): Promise<Manifest | null> {
   }
 }
 
-// build epoch of a stored artifact, read without a full parse; no generatedAt means it's not a v2 artifact
+// an artifact's build epoch without a full parse; no generatedAt means it isn't a v2 artifact
 export function storedEpoch(entry: Entry): number | undefined {
   return epochOfHead(entry.buf.subarray(0, 200).toString("utf8"));
 }
@@ -165,12 +156,15 @@ export type Gate = { manifest: Manifest; age: number; stale: boolean };
 export async function buildGate(res: HyperExpress.Response): Promise<Gate | null> {
   const manifest = await loadManifest();
   if (!manifest) {
-    sendV2Error(res, 503, "build_unavailable", "no completed v2 build is available yet");
+    // client-facing messages stay generic - the operational detail goes to the log, not the response
+    console.error("v2: no readable _manifest, refusing to serve");
+    sendV2Error(res, 503, "build_unavailable", "data is not available yet");
     return null;
   }
   const age = Math.floor(Date.now() / 1e3) - manifest.generatedAt;
   if (age > V2_MAX_AGE) {
-    sendV2Error(res, 503, "build_stale", `the last v2 build is ${age}s old, past the ${V2_MAX_AGE}s ceiling`);
+    console.error(`v2: refusing to serve, data is ${age}s old against a ${V2_MAX_AGE}s ceiling`);
+    sendV2Error(res, 503, "build_stale", "data is temporarily unavailable");
     return null;
   }
   return { manifest, age, stale: age > V2_STALE_AFTER };
@@ -186,18 +180,17 @@ function setCommonHeaders(res: HyperExpress.Response, kind: CacheKind, generated
   res.setHeader("Content-Type", "application/json");
   res.setHeader("Cache-Control", CACHE_HEADERS[kind]);
   res.setHeader("ETag", etag);
-  // every response can vary by encoding - a shared cache mustn't key differently-encoded responses as one
+  // a shared cache must not key differently-encoded responses as one
   res.setHeader("Vary", "Accept-Encoding");
   if (generatedAt !== undefined) res.setHeader("x-generated-at", String(generatedAt));
   if (gate?.stale) {
-    // loud, machine-readable degradation rather than a silently old 200
     res.setHeader("Warning", `110 - "Response is Stale"`);
     res.setHeader("x-stale", "true");
     res.setHeader("x-build-age", String(gate.age));
   }
 }
 
-// RFC 7232 §3.2: If-None-Match is weak-compared, comma-list + `*`; Cloudflare weakens ETags on compressed responses
+// RFC 7232 §3.2: comma-list + `*`, weak comparison - Cloudflare weakens ETags on compressed responses
 function ifNoneMatchHits(header: string | undefined, etag: string): boolean {
   if (!header) return false;
   const opaque = (t: string) => t.trim().replace(/^W\//, "");
@@ -223,7 +216,7 @@ function acceptsBrotli(header: string | undefined): boolean {
   return wildcard;
 }
 
-// whole-file path never parses, so this is the only check that a truncated payload doesn't go out as a cacheable 200
+// the whole-file path never parses, so this is the only thing stopping a truncated payload from going out as a cacheable 200
 function endsClosed(buf: Buffer): boolean {
   for (let i = buf.length - 1; i >= 0 && i > buf.length - 8; i--) {
     const c = buf[i];
@@ -233,17 +226,19 @@ function endsClosed(buf: Buffer): boolean {
   return false;
 }
 
-// checks the stored file's epoch matches the completed build; responds and returns undefined if it may not be served
-function checkedEpoch(res: HyperExpress.Response, entry: Entry, gate?: Gate): number | undefined {
+// checks the file's epoch against the completed build; responds and returns undefined if unservable
+export function checkedEpoch(res: HyperExpress.Response, entry: Entry, gate?: Gate): number | undefined {
   const epoch = storedEpoch(entry);
   if (epoch === undefined || !endsClosed(entry.buf)) {
-    // not a v2 artifact, or one that does not close: never serve it as if it were
-    sendV2Error(res, 500, "corrupt_artifact", "stored artifact is not a valid v2 payload");
+    // not a v2 artifact, or one that doesn't close: never serve it as if it were
+    console.error(`v2: refusing to serve "${entry.key}" - not a valid v2 payload`);
+    sendV2Error(res, 500, "corrupt_artifact", "data is temporarily unavailable");
     return undefined;
   }
   if (gate && epoch !== gate.manifest.generatedAt) {
-    // a file from a different cron run than the completed build: the set on disk is torn
-    sendV2Error(res, 503, "build_torn", "the stored build is incoherent; a cron run did not complete");
+    // a file from a different run than the completed build - the set on disk is torn
+    console.error(`v2: refusing to serve "${entry.key}" - epoch ${epoch} against manifest ${gate.manifest.generatedAt}`);
+    sendV2Error(res, 503, "build_torn", "data is temporarily unavailable");
     return undefined;
   }
   return epoch;
@@ -252,7 +247,7 @@ function checkedEpoch(res: HyperExpress.Response, entry: Entry, gate?: Gate): nu
 export function sendV2Entry(req: HyperExpress.Request, res: HyperExpress.Response, entry: Entry, kind: CacheKind, gate?: Gate) {
   const epoch = checkedEpoch(res, entry, gate);
   if (epoch === undefined) return;
-  // compressed and identity responses are different representations - must not share an ETag
+  // compressed and identity are different representations - they must not share an ETag
   const wantsBr = entry.br !== undefined && acceptsBrotli(String(req.headers["accept-encoding"] ?? ""));
   const etag = wantsBr ? entry.etag.slice(0, -1) + '-br"' : entry.etag;
   setCommonHeaders(res, kind, epoch, etag, gate);
@@ -264,7 +259,7 @@ export function sendV2Entry(req: HyperExpress.Request, res: HyperExpress.Respons
   return res.send(entry.buf as any);
 }
 
-// a sliced response's ETag is derivable before the payload is built, so a 304 never parses/slices/hashes the file
+// the ETag is derivable before the payload is built, so a 304 never parses, slices or hashes
 export function sendV2Sliced(
   req: HyperExpress.Request,
   res: HyperExpress.Response,
@@ -280,6 +275,22 @@ export function sendV2Sliced(
   setCommonHeaders(res, kind, epoch, etag, gate);
   if (ifNoneMatchHits(req.headers["if-none-match"], etag)) return res.status(304).send("");
   return res.send(JSON.stringify(build(epoch)));
+}
+
+// A scoped entity that this metric simply has no data for is a permanently correct empty answer, not an origin failure
+export function sendV2Empty(
+  req: HyperExpress.Request,
+  res: HyperExpress.Response,
+  discriminator: string,
+  kind: CacheKind,
+  gate: Gate,
+  payload: any
+) {
+  const epoch = gate.manifest.generatedAt;
+  const etag = '"' + crypto.createHash("md5").update(`empty ${epoch} ${discriminator}`).digest("hex") + '"';
+  setCommonHeaders(res, kind, epoch, etag, gate);
+  if (ifNoneMatchHits(req.headers["if-none-match"], etag)) return res.status(304).send("");
+  return res.send(JSON.stringify(payload));
 }
 
 export function sendV2Error(res: HyperExpress.Response, statusCode: number, code: string, message: string) {

--- a/api2/v2/serve.ts
+++ b/api2/v2/serve.ts
@@ -1,0 +1,308 @@
+import crypto from "crypto";
+import fs from "fs";
+import zlib from "zlib";
+import * as HyperExpress from "hyper-express";
+import { getRouteDataPath } from "../file-cache";
+
+const num = (v: string | undefined, fallback: number) => (v && /^\d+$/.test(v) ? Number(v) : fallback);
+
+const epochOfHead = (head: string): number | undefined => {
+  const match = head.match(/"generatedAt":\s*(\d+)/);
+  return match ? Number(match[1]) : undefined;
+};
+
+const LRU_MAX = num(process.env.STABLECOINS_V2_LRU_ENTRIES, 32);
+const LRU_MAX_BYTES = num(process.env.STABLECOINS_V2_LRU_BYTES, 192 * 1024 * 1024);
+type Entry = { key: string; mtimeMs: number; brMtimeMs?: number; buf: Buffer; etag: string; br?: Buffer; parsed?: any; bytes: number };
+const lru = new Map<string, Entry>();
+let lruBytes = 0;
+
+const mtimeOf = async (filePath: string): Promise<number | undefined> => {
+  try {
+    return (await fs.promises.stat(filePath)).mtimeMs;
+  } catch {
+    return undefined;
+  }
+};
+
+function retain(entry: Entry) {
+  const prev = lru.get(entry.key);
+  if (prev) lruBytes -= prev.bytes;
+  lru.delete(entry.key);
+  lru.set(entry.key, entry);
+  lruBytes += entry.bytes;
+  evict();
+}
+
+function evict() {
+  while (lru.size > LRU_MAX || (lruBytes > LRU_MAX_BYTES && lru.size > 1)) {
+    const oldest = lru.keys().next().value;
+    if (oldest === undefined) return;
+    lruBytes -= lru.get(oldest)!.bytes;
+    lru.delete(oldest);
+  }
+}
+
+// dedupes concurrent misses on the same file - avoids a post-cron stampede re-reading the same buffer
+const inflight = new Map<string, Promise<Entry | null>>();
+
+export async function loadV2File(subPath: string): Promise<Entry | null> {
+  const filePath = getRouteDataPath(`v2/${subPath}`);
+  const [mtimeMs, brMtimeMs] = await Promise.all([mtimeOf(filePath), mtimeOf(filePath + ".br")]);
+  if (mtimeMs === undefined) return null;
+
+  const existing = lru.get(subPath);
+  if (existing && existing.mtimeMs === mtimeMs && existing.brMtimeMs === brMtimeMs) {
+    lru.delete(subPath);
+    lru.set(subPath, existing);
+    return existing;
+  }
+
+  const key = `${subPath} ${mtimeMs} ${brMtimeMs ?? ""}`;
+  let pending = inflight.get(key);
+  if (!pending) {
+    pending = readEntry(subPath, filePath).finally(() => inflight.delete(key));
+    inflight.set(key, pending);
+  }
+  return pending;
+}
+
+// decompresses only until `bytes` of output exist, so checking a sibling costs one chunk, not a full inflate
+function inflateHead(buf: Buffer, bytes: number): Promise<string> {
+  return new Promise((resolve) => {
+    const stream = zlib.createBrotliDecompress();
+    let out = "";
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      stream.destroy();
+      resolve(out);
+    };
+    stream.on("data", (chunk: Buffer) => {
+      out += chunk.toString("utf8");
+      if (out.length >= bytes) finish();
+    });
+    stream.on("end", finish);
+    stream.on("error", finish);
+    stream.end(buf);
+  });
+}
+
+async function readEntry(subPath: string, filePath: string): Promise<Entry | null> {
+  // read both files then re-stat both - if either moved, we may have mixed two builds and must retry
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const [m0, b0] = await Promise.all([mtimeOf(filePath), mtimeOf(filePath + ".br")]);
+    if (m0 === undefined) return null;
+    const [buf, brRead] = await Promise.all([
+      fs.promises.readFile(filePath),
+      // absent/unreadable .br just means "send it raw"
+      b0 === undefined ? Promise.resolve(undefined) : fs.promises.readFile(filePath + ".br").catch(() => undefined),
+    ]);
+    const [m1, b1] = await Promise.all([mtimeOf(filePath), mtimeOf(filePath + ".br")]);
+    if (m1 !== m0 || b1 !== b0) continue;
+
+    // sibling accepted only if it decompresses to the same build epoch - else a compressed client could get another build's bytes under this ETag
+    const epoch = epochOfHead(buf.subarray(0, 200).toString("utf8"));
+    const br = brRead && epoch !== undefined && epochOfHead(await inflateHead(brRead, 200)) === epoch ? brRead : undefined;
+    const entry: Entry = {
+      key: subPath,
+      mtimeMs: m0,
+      brMtimeMs: b0,
+      buf,
+      br,
+      bytes: buf.length + (br?.length ?? 0),
+      etag: '"' + crypto.createHash("md5").update(buf).digest("hex") + '"',
+    };
+    retain(entry);
+    return entry;
+  }
+  throw new Error(`v2: could not read a stable copy of ${subPath}`);
+}
+
+export function parsedOf(entry: Entry): any {
+  if (entry.parsed === undefined) {
+    entry.parsed = JSON.parse(entry.buf.toString("utf8"));
+    if (lru.get(entry.key) === entry) {
+      entry.bytes += entry.buf.length;
+      lruBytes += entry.buf.length;
+      evict();
+    }
+  }
+  return entry.parsed;
+}
+
+// build freshness: answerable only when a completed build exists, isn't past the age ceiling, and the file's epoch matches `_manifest`'s
+
+// mark responses stale past this age; refuse to serve past the ceiling
+export const V2_STALE_AFTER = num(process.env.STABLECOINS_V2_STALE_AFTER, 3 * 3600);
+export const V2_MAX_AGE = num(process.env.STABLECOINS_V2_MAX_AGE, 24 * 3600);
+if (V2_STALE_AFTER >= V2_MAX_AGE) {
+  throw new Error(`v2: STABLECOINS_V2_STALE_AFTER (${V2_STALE_AFTER}) must be below STABLECOINS_V2_MAX_AGE (${V2_MAX_AGE})`);
+}
+
+export type Manifest = { generatedAt: number; files: number; assets: number; chains: number };
+
+export async function loadManifest(): Promise<Manifest | null> {
+  const entry = await loadV2File("_manifest");
+  if (!entry) return null;
+  try {
+    const m = parsedOf(entry);
+    return typeof m?.generatedAt === "number" ? m : null;
+  } catch {
+    return null;
+  }
+}
+
+// build epoch of a stored artifact, read without a full parse; no generatedAt means it's not a v2 artifact
+export function storedEpoch(entry: Entry): number | undefined {
+  return epochOfHead(entry.buf.subarray(0, 200).toString("utf8"));
+}
+
+export type Gate = { manifest: Manifest; age: number; stale: boolean };
+
+// resolves the build state, or responds and returns null when nothing may be served
+export async function buildGate(res: HyperExpress.Response): Promise<Gate | null> {
+  const manifest = await loadManifest();
+  if (!manifest) {
+    sendV2Error(res, 503, "build_unavailable", "no completed v2 build is available yet");
+    return null;
+  }
+  const age = Math.floor(Date.now() / 1e3) - manifest.generatedAt;
+  if (age > V2_MAX_AGE) {
+    sendV2Error(res, 503, "build_stale", `the last v2 build is ${age}s old, past the ${V2_MAX_AGE}s ceiling`);
+    return null;
+  }
+  return { manifest, age, stale: age > V2_STALE_AFTER };
+}
+
+export type CacheKind = "current" | "history";
+const CACHE_HEADERS: Record<CacheKind, string> = {
+  current: "public, max-age=300, stale-while-revalidate=600",
+  history: "public, max-age=1800, stale-while-revalidate=3600",
+};
+
+function setCommonHeaders(res: HyperExpress.Response, kind: CacheKind, generatedAt: number | undefined, etag: string, gate?: Gate) {
+  res.setHeader("Content-Type", "application/json");
+  res.setHeader("Cache-Control", CACHE_HEADERS[kind]);
+  res.setHeader("ETag", etag);
+  // every response can vary by encoding - a shared cache mustn't key differently-encoded responses as one
+  res.setHeader("Vary", "Accept-Encoding");
+  if (generatedAt !== undefined) res.setHeader("x-generated-at", String(generatedAt));
+  if (gate?.stale) {
+    // loud, machine-readable degradation rather than a silently old 200
+    res.setHeader("Warning", `110 - "Response is Stale"`);
+    res.setHeader("x-stale", "true");
+    res.setHeader("x-build-age", String(gate.age));
+  }
+}
+
+// RFC 7232 §3.2: If-None-Match is weak-compared, comma-list + `*`; Cloudflare weakens ETags on compressed responses
+function ifNoneMatchHits(header: string | undefined, etag: string): boolean {
+  if (!header) return false;
+  const opaque = (t: string) => t.trim().replace(/^W\//, "");
+  if (header.trim() === "*") return true;
+  const want = opaque(etag);
+  return header.split(",").some((candidate) => opaque(candidate) === want);
+}
+
+// RFC 9110 §12.5.3: q=0 means not acceptable (`br;q=0` must not get brotli); explicit `br` outranks `*`
+function acceptsBrotli(header: string | undefined): boolean {
+  if (!header) return false;
+  let wildcard = false;
+  for (const part of header.split(",")) {
+    const [token, ...params] = part.split(";");
+    const name = token.trim().toLowerCase();
+    if (name !== "br" && name !== "*") continue;
+    const qParam = params.map((p) => p.trim().toLowerCase()).find((p) => p.startsWith("q="));
+    const q = qParam ? Number(qParam.slice(2)) : 1;
+    const acceptable = Number.isFinite(q) && q > 0;
+    if (name === "br") return acceptable;
+    wildcard = acceptable;
+  }
+  return wildcard;
+}
+
+// whole-file path never parses, so this is the only check that a truncated payload doesn't go out as a cacheable 200
+function endsClosed(buf: Buffer): boolean {
+  for (let i = buf.length - 1; i >= 0 && i > buf.length - 8; i--) {
+    const c = buf[i];
+    if (c === 0x20 || c === 0x0a || c === 0x0d || c === 0x09) continue;
+    return c === 0x7d; // }
+  }
+  return false;
+}
+
+// checks the stored file's epoch matches the completed build; responds and returns undefined if it may not be served
+function checkedEpoch(res: HyperExpress.Response, entry: Entry, gate?: Gate): number | undefined {
+  const epoch = storedEpoch(entry);
+  if (epoch === undefined || !endsClosed(entry.buf)) {
+    // not a v2 artifact, or one that does not close: never serve it as if it were
+    sendV2Error(res, 500, "corrupt_artifact", "stored artifact is not a valid v2 payload");
+    return undefined;
+  }
+  if (gate && epoch !== gate.manifest.generatedAt) {
+    // a file from a different cron run than the completed build: the set on disk is torn
+    sendV2Error(res, 503, "build_torn", "the stored build is incoherent; a cron run did not complete");
+    return undefined;
+  }
+  return epoch;
+}
+
+export function sendV2Entry(req: HyperExpress.Request, res: HyperExpress.Response, entry: Entry, kind: CacheKind, gate?: Gate) {
+  const epoch = checkedEpoch(res, entry, gate);
+  if (epoch === undefined) return;
+  // compressed and identity responses are different representations - must not share an ETag
+  const wantsBr = entry.br !== undefined && acceptsBrotli(String(req.headers["accept-encoding"] ?? ""));
+  const etag = wantsBr ? entry.etag.slice(0, -1) + '-br"' : entry.etag;
+  setCommonHeaders(res, kind, epoch, etag, gate);
+  if (ifNoneMatchHits(req.headers["if-none-match"], etag)) return res.status(304).send("");
+  if (wantsBr) {
+    res.setHeader("Content-Encoding", "br");
+    return res.send(entry.br as any);
+  }
+  return res.send(entry.buf as any);
+}
+
+// a sliced response's ETag is derivable before the payload is built, so a 304 never parses/slices/hashes the file
+export function sendV2Sliced(
+  req: HyperExpress.Request,
+  res: HyperExpress.Response,
+  entry: Entry,
+  discriminator: string,
+  kind: CacheKind,
+  gate: Gate | undefined,
+  build: (epoch: number) => any
+) {
+  const epoch = checkedEpoch(res, entry, gate);
+  if (epoch === undefined) return;
+  const etag = '"' + crypto.createHash("md5").update(entry.etag).update(" ").update(discriminator).digest("hex") + '"';
+  setCommonHeaders(res, kind, epoch, etag, gate);
+  if (ifNoneMatchHits(req.headers["if-none-match"], etag)) return res.status(304).send("");
+  return res.send(JSON.stringify(build(epoch)));
+}
+
+export function sendV2Error(res: HyperExpress.Response, statusCode: number, code: string, message: string) {
+  res.status(statusCode);
+  res.setHeader("Content-Type", "application/json");
+  res.setHeader("Cache-Control", "no-store");
+  return res.send(JSON.stringify({ error: { code, message } }));
+}
+
+export function sendV2Redirect(res: HyperExpress.Response, location: string) {
+  res.status(301);
+  res.setHeader("Location", location);
+  res.setHeader("Cache-Control", "public, max-age=3600");
+  return res.send("");
+}
+
+export function v2Wrapper(routeFn: any) {
+  return async (req: HyperExpress.Request, res: HyperExpress.Response) => {
+    try {
+      await routeFn(req, res);
+    } catch (e: any) {
+      console.error("v2 route error", req?.url, e);
+      if (!res.completed) sendV2Error(res, 500, "internal_error", "internal error serving a v2 response");
+    }
+  };
+}

--- a/api2/v2/serve.ts
+++ b/api2/v2/serve.ts
@@ -171,14 +171,21 @@ export async function buildGate(res: HyperExpress.Response): Promise<Gate | null
 }
 
 export type CacheKind = "current" | "history";
-const CACHE_HEADERS: Record<CacheKind, string> = {
-  current: "public, max-age=300, stale-while-revalidate=600",
-  history: "public, max-age=1800, stale-while-revalidate=3600",
+const CACHE_TTL: Record<CacheKind, { maxAge: number; swr: number }> = {
+  current: { maxAge: 300, swr: 600 },
+  history: { maxAge: 1800, swr: 3600 },
 };
+
+function cacheControl(kind: CacheKind, gate?: Gate): string {
+  const { maxAge, swr } = CACHE_TTL[kind];
+  const budget = gate ? (gate.stale ? V2_MAX_AGE : V2_STALE_AFTER) - gate.age : Infinity;
+  const cappedMaxAge = Math.min(maxAge, budget);
+  return `public, max-age=${cappedMaxAge}, stale-while-revalidate=${Math.min(swr, budget - cappedMaxAge)}`;
+}
 
 function setCommonHeaders(res: HyperExpress.Response, kind: CacheKind, generatedAt: number | undefined, etag: string, gate?: Gate) {
   res.setHeader("Content-Type", "application/json");
-  res.setHeader("Cache-Control", CACHE_HEADERS[kind]);
+  res.setHeader("Cache-Control", cacheControl(kind, gate));
   res.setHeader("ETag", etag);
   // a shared cache must not key differently-encoded responses as one
   res.setHeader("Vary", "Accept-Encoding");

--- a/api2/v2/shared.ts
+++ b/api2/v2/shared.ts
@@ -1,0 +1,229 @@
+import * as sdk from "@defillama/sdk";
+import peggedAssets from "../../src/peggedData/peggedData";
+import sluggifyPegged from "../../src/peggedAssets/utils/sluggifyPegged";
+import { pegTypeFxTicker } from "../../src/utils/fxRates";
+
+export type Tuple = [number, number];
+export type Resolution = "daily" | "weekly" | "monthly";
+export const RESOLUTIONS: Resolution[] = ["daily", "weekly", "monthly"];
+
+export type AssetInfo = {
+  id: number;
+  slug: string;
+  name: string;
+  symbol: string;
+  geckoId: string | null;
+  pegType: string;
+  pegCurrency: string;
+  pegMechanism: string | null;
+  doublecounted: boolean;
+  deprecated: boolean;
+  delisted: boolean;
+  yieldBearing: boolean;
+  deadFrom: number | null;
+  raw: any;
+};
+
+export type AssetRegistry = {
+  bySlug: Map<string, AssetInfo>;
+  byId: Map<string, AssetInfo>;
+  byGeckoId: Map<string, AssetInfo>;
+  bySymbol: Map<string, AssetInfo[]>;
+  all: AssetInfo[];
+  // entries that couldn't be keyed at all; build refuses to publish while non-empty
+  issues: string[];
+  // asset is fine but a secondary index is ambiguous; logged, not fatal
+  warnings: string[];
+};
+
+let _registry: AssetRegistry | null = null;
+
+// skips unusable peggedData entries into `issues` rather than throwing; build refuses to publish while `issues` is non-empty
+export function assetRegistry(): AssetRegistry {
+  if (_registry) return _registry;
+  const bySlug = new Map<string, AssetInfo>();
+  const byId = new Map<string, AssetInfo>();
+  const byGeckoId = new Map<string, AssetInfo>();
+  const bySymbol = new Map<string, AssetInfo[]>();
+  const all: AssetInfo[] = [];
+  const issues: string[] = [];
+  const warnings: string[] = [];
+  const ambiguousGeckoIds = new Set<string>();
+
+  for (const pegged of peggedAssets as any[]) {
+    const id = Number(pegged?.id);
+    if (!Number.isFinite(id)) {
+      issues.push(`asset id ${JSON.stringify(pegged?.id)} is not numeric`);
+      continue;
+    }
+    if (typeof pegged.name !== "string" || !pegged.name) {
+      issues.push(`asset id ${id} has no name (cannot be slugged)`);
+      continue;
+    }
+    if (typeof pegged.pegType !== "string" || !pegged.pegType) {
+      issues.push(`asset id ${id} ("${pegged.name}") has no pegType`);
+      continue;
+    }
+
+    let slug = sluggifyPegged(pegged);
+    if (bySlug.has(slug)) {
+      // slug collision can't be resolved without diverging from v1 - record and skip so one doesn't silently overwrite the other's files
+      issues.push(`slug collision on "${slug}" (ids ${bySlug.get(slug)!.id}, ${id}) - v1 keys by the same slug`);
+      continue;
+    }
+    if (byId.has(String(id))) {
+      issues.push(`duplicate asset id ${id} ("${pegged.name}")`);
+      continue;
+    }
+
+    const info: AssetInfo = {
+      id,
+      slug,
+      name: pegged.name,
+      symbol: pegged.symbol,
+      geckoId: pegged.gecko_id ?? null,
+      pegType: pegged.pegType,
+      pegCurrency: pegTypeFxTicker(pegged.pegType),
+      pegMechanism: pegged.pegMechanism ?? null,
+      doublecounted: pegged.doublecounted === true,
+      deprecated: pegged.deprecated === true,
+      delisted: pegged.delisted === true,
+      yieldBearing: pegged.yieldBearing === true,
+      deadFrom: pegged.deadFrom ?? null,
+      raw: pegged,
+    };
+    bySlug.set(slug, info);
+    byId.set(String(id), info);
+    if (info.geckoId) {
+      if (byGeckoId.has(info.geckoId)) {
+        warnings.push(`gecko_id "${info.geckoId}" claimed by ids ${byGeckoId.get(info.geckoId)!.id} and ${id} - not resolvable to one asset`);
+        ambiguousGeckoIds.add(info.geckoId);
+      } else {
+        byGeckoId.set(info.geckoId, info);
+      }
+    }
+    const symbolKey = (pegged.symbol ?? "").toUpperCase();
+    if (!bySymbol.has(symbolKey)) bySymbol.set(symbolKey, []);
+    bySymbol.get(symbolKey)!.push(info);
+    all.push(info);
+  }
+  for (const geckoId of ambiguousGeckoIds) byGeckoId.delete(geckoId);
+  for (const issue of issues) console.error(`v2 registry: ${issue}`);
+  for (const warning of warnings) console.warn(`v2 registry: ${warning}`);
+
+  _registry = { bySlug, byId, byGeckoId, bySymbol, all, issues, warnings };
+  return _registry;
+}
+
+// v2's public chain slug, derived from the display label - NOT v1's per-chain cache filename, which slugs the lowercased chain key instead
+export function chainSlugFromLabel(label: string): string {
+  return sdk.chainUtils.sluggifyString(label);
+}
+
+export const sumRecord = (rec: any): number => {
+  let total = 0;
+  for (const v of Object.values(rec ?? {})) if (typeof v === "number" && isFinite(v)) total += v;
+  return total;
+};
+
+// null = unknown, 0 = measured zero - an empty/all-null record must not collapse to a fake $0
+export const sumRecordOrNull = (rec: any): number | null => {
+  if (!rec || typeof rec !== "object") return null;
+  let total = 0;
+  let seen = false;
+  for (const v of Object.values(rec)) {
+    if (typeof v === "number" && isFinite(v)) {
+      total += v;
+      seen = true;
+    }
+  }
+  return seen ? Math.round(total) : null;
+};
+
+export function identitySeriesFields(info: AssetInfo) {
+  return {
+    id: info.id,
+    slug: info.slug,
+    name: info.name,
+    symbol: info.symbol,
+    ...(info.doublecounted ? { doublecounted: true } : {}),
+  };
+}
+
+// weekly = Monday-start UTC, monthly = UTC calendar month; keeps the last point per bucket (period-end, no averaging)
+function bucketOf(ts: number, resolution: Resolution): number {
+  const day = Math.floor(ts / 86400);
+  if (resolution === "weekly") return Math.floor((day - 4) / 7); // epoch day 4 = Monday 1970-01-05
+  return monthIndexOfDay(day);
+}
+
+// UTC year*12+month via civil-calendar arithmetic - avoids allocating a Date per point
+function monthIndexOfDay(day: number): number {
+  const z = day + 719468;
+  const era = Math.floor(z / 146097);
+  const doe = z - era * 146097;
+  const yoe = Math.floor((doe - Math.floor(doe / 1460) + Math.floor(doe / 36524) - Math.floor(doe / 146096)) / 365);
+  const doy = doe - (365 * yoe + Math.floor(yoe / 4) - Math.floor(yoe / 100));
+  const mp = Math.floor((5 * doy + 2) / 153);
+  const month = mp < 10 ? mp + 3 : mp - 9; // 1-12
+  const year = yoe + era * 400 + (month <= 2 ? 1 : 0);
+  return year * 12 + (month - 1);
+}
+
+// PRECONDITION: `data` is ascending by timestamp, so "last write wins" is the chronologically last point
+export function sampleTuples(data: Tuple[], resolution: Resolution): Tuple[] {
+  if (resolution === "daily") return data;
+  const byBucket = new Map<number, Tuple>();
+  for (const point of data) byBucket.set(bucketOf(point[0], resolution), point);
+  return [...byBucket.values()];
+}
+
+// PRECONDITION: `data` is ascending by timestamp - binary search finds the contiguous range; hot path, must not be linear
+export function sliceTuples(data: Tuple[], start?: number, end?: number): Tuple[] {
+  if (start === undefined && end === undefined) return data;
+  const from = start === undefined ? 0 : lowerBound(data, start);
+  const to = end === undefined ? data.length : upperBound(data, end);
+  if (to <= from) return [];
+  if (from === 0 && to === data.length) return data; // fully covered: no copy
+  return data.slice(from, to);
+}
+
+// first index whose timestamp is >= ts
+function lowerBound(data: Tuple[], ts: number): number {
+  let lo = 0;
+  let hi = data.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (data[mid][0] < ts) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
+// first index whose timestamp is > ts (so `end` stays inclusive)
+function upperBound(data: Tuple[], ts: number): number {
+  let lo = 0;
+  let hi = data.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (data[mid][0] <= ts) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
+export function pointsToTuples(points: any[], field: string): Tuple[] {
+  const out: Tuple[] = [];
+  let ascending = true;
+  for (const p of points ?? []) {
+    if (!p) continue;
+    const value = p[field];
+    if (value === undefined || value === null || typeof value !== "object") continue;
+    const ts = Number(p.date);
+    if (!Number.isFinite(ts)) continue;
+    if (out.length && ts < out[out.length - 1][0]) ascending = false;
+    out.push([ts, Math.round(sumRecord(value))]);
+  }
+  if (!ascending) out.sort((a, b) => a[0] - b[0]);
+  return out;
+}

--- a/api2/v2/shared.ts
+++ b/api2/v2/shared.ts
@@ -169,13 +169,15 @@ function monthIndexOfDay(day: number): number {
   return year * 12 + (month - 1);
 }
 
-// keeps one point per bucket, no averaging. PRECONDITION: `data` ascends by timestamp, so the last
-// write into a bucket is its period-end point
-export function sampleTuples(data: Tuple[], resolution: Resolution): Tuple[] {
-  if (resolution === "daily") return data;
-  const byBucket = new Map<number, Tuple>();
-  for (const point of data) byBucket.set(bucketOf(point[0], resolution), point);
-  return [...byBucket.values()];
+export function sampleByResolution(data: Tuple[]): Record<Resolution, Tuple[]> {
+  const weekly = new Map<number, Tuple>();
+  const monthly = new Map<number, Tuple>();
+  for (const point of data) {
+    const day = Math.floor(point[0] / 86400);
+    weekly.set(Math.floor((day - 4) / 7), point);
+    monthly.set(monthIndexOfDay(day), point);
+  }
+  return { daily: data, weekly: [...weekly.values()], monthly: [...monthly.values()] };
 }
 
 // PRECONDITION: `data` ascends by timestamp - hot path, so the range is found by binary search

--- a/api2/v2/shared.ts
+++ b/api2/v2/shared.ts
@@ -30,15 +30,15 @@ export type AssetRegistry = {
   byGeckoId: Map<string, AssetInfo>;
   bySymbol: Map<string, AssetInfo[]>;
   all: AssetInfo[];
-  // entries that couldn't be keyed at all; build refuses to publish while non-empty
+  // unkeyable entries; build refuses to publish while non-empty
   issues: string[];
-  // asset is fine but a secondary index is ambiguous; logged, not fatal
+  // asset is usable but a secondary index is ambiguous; logged, not fatal
   warnings: string[];
 };
 
 let _registry: AssetRegistry | null = null;
 
-// skips unusable peggedData entries into `issues` rather than throwing; build refuses to publish while `issues` is non-empty
+// unusable peggedData entries go to `issues` instead of throwing - the caller decides what to do
 export function assetRegistry(): AssetRegistry {
   if (_registry) return _registry;
   const bySlug = new Map<string, AssetInfo>();
@@ -67,7 +67,6 @@ export function assetRegistry(): AssetRegistry {
 
     let slug = sluggifyPegged(pegged);
     if (bySlug.has(slug)) {
-      // slug collision can't be resolved without diverging from v1 - record and skip so one doesn't silently overwrite the other's files
       issues.push(`slug collision on "${slug}" (ids ${bySlug.get(slug)!.id}, ${id}) - v1 keys by the same slug`);
       continue;
     }
@@ -115,7 +114,7 @@ export function assetRegistry(): AssetRegistry {
   return _registry;
 }
 
-// v2's public chain slug, derived from the display label - NOT v1's per-chain cache filename, which slugs the lowercased chain key instead
+// v2's public chain slug, from the display label
 export function chainSlugFromLabel(label: string): string {
   return sdk.chainUtils.sluggifyString(label);
 }
@@ -150,14 +149,14 @@ export function identitySeriesFields(info: AssetInfo) {
   };
 }
 
-// weekly = Monday-start UTC, monthly = UTC calendar month; keeps the last point per bucket (period-end, no averaging)
+// weekly = Monday-start UTC, monthly = UTC calendar month
 function bucketOf(ts: number, resolution: Resolution): number {
   const day = Math.floor(ts / 86400);
   if (resolution === "weekly") return Math.floor((day - 4) / 7); // epoch day 4 = Monday 1970-01-05
   return monthIndexOfDay(day);
 }
 
-// UTC year*12+month via civil-calendar arithmetic - avoids allocating a Date per point
+// UTC year*12+month by civil-calendar arithmetic - no Date allocation per point
 function monthIndexOfDay(day: number): number {
   const z = day + 719468;
   const era = Math.floor(z / 146097);
@@ -170,7 +169,8 @@ function monthIndexOfDay(day: number): number {
   return year * 12 + (month - 1);
 }
 
-// PRECONDITION: `data` is ascending by timestamp, so "last write wins" is the chronologically last point
+// keeps one point per bucket, no averaging. PRECONDITION: `data` ascends by timestamp, so the last
+// write into a bucket is its period-end point
 export function sampleTuples(data: Tuple[], resolution: Resolution): Tuple[] {
   if (resolution === "daily") return data;
   const byBucket = new Map<number, Tuple>();
@@ -178,7 +178,7 @@ export function sampleTuples(data: Tuple[], resolution: Resolution): Tuple[] {
   return [...byBucket.values()];
 }
 
-// PRECONDITION: `data` is ascending by timestamp - binary search finds the contiguous range; hot path, must not be linear
+// PRECONDITION: `data` ascends by timestamp - hot path, so the range is found by binary search
 export function sliceTuples(data: Tuple[], start?: number, end?: number): Tuple[] {
   if (start === undefined && end === undefined) return data;
   const from = start === undefined ? 0 : lowerBound(data, start);


### PR DESCRIPTION
Implements the [v2 proposal](https://stablecoins-v2-proposal.vercel.app/).

## API

```text
GET /v2/assets[?chain=]
GET /v2/assets/:asset
GET /v2/chains

GET /v2/history/market-cap
GET /v2/history/volume
GET /v2/history/supply
```


### Payload impact

|                      |                     v1 |     v2 |
| -------------------- | ---------------------: | --------------: |
| Global market cap    | 3.25 MB / 194 ms parse |  27 KB / 0.3 ms |
| Full asset breakdown |                 ~36 MB | 1.46 MB / 70 ms |
| Weekly breakdown     |                      — | 256 KB / 3.9 ms |

## Implementation

`api2/v2/build.ts` transforms the v1 route files produced by the existing cron.

`_manifest` is written last and gates publication. Serving rejects epoch mismatches, refuses builds >24h old, and marks builds >3h old as stale. Builds abort on missing/empty required sources to avoid publishing partial data.

## Key decisions

* **Market cap:** preserves v1 price-adjusted semantics. USD fields use `*Usd`; raw counts are only under `/history/supply` with `unit: "count"`.
* **Double-counted assets:** excluded from totals server-side (66/413), but still returned by `groupBy=asset` with their flag.
* **Resolution:** period-end sampling; no averaging.
* **No `limit` / `Others`:** clients can derive `total − Σ(top N)` from the small response.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a V2 API with asset, chain, market-cap, volume, and supply endpoints.
  - Added daily, weekly, and monthly history views with date filtering and chain-specific data.
  - Added compressed responses, caching, ETags, and conditional requests for faster delivery.
  - Added automated generation of V2 data files and build metadata.
  - Added standardized errors, redirects, and unavailable-data responses.

- **Bug Fixes**
  - Added safeguards to prevent serving incomplete, stale, corrupted, or regressed data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->