### PR TITLE
add delpho usdv

### DIFF
--- a/src/adapters/peggedAssets/delpho-usdv/index.ts
+++ b/src/adapters/peggedAssets/delpho-usdv/index.ts
@@ -1,0 +1,41 @@
+import { ChainBlocks, PeggedIssuanceAdapter } from "../peggedAsset.type";
+const sdk = require("@defillama/sdk");
+
+const CONFIG_PROVIDER = "0xeC884577055e1f32f2579CAB9f348F4918Cd757f";
+
+async function hyperliquidMinted() {
+  return async function (
+    _timestamp: number,
+    _ethBlock: number,
+    chainBlocks: ChainBlocks
+  ) {
+    const usdvAddress = (
+      await sdk.api.abi.call({
+        abi: "address:delphoStable",
+        target: CONFIG_PROVIDER,
+        chain: "hyperliquid",
+        block: chainBlocks["hyperliquid"],
+      })
+    ).output;
+
+    const totalSupply = (
+      await sdk.api.abi.call({
+        abi: "erc20:totalSupply",
+        target: usdvAddress,
+        chain: "hyperliquid",
+        block: chainBlocks["hyperliquid"],
+      })
+    ).output;
+
+    return { peggedUSD: totalSupply / 10 ** 6 };
+  };
+}
+
+const adapter: PeggedIssuanceAdapter = {
+  hyperliquid: {
+    minted: hyperliquidMinted(),
+    unreleased: async () => ({}),
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
**NOTE**

Name (to be shown on DefiLlama): Delpho USDV
Website Link: https://www.delpho.xyz
Logo (High resolution, will be shown with rounded borders): https://app.delpho.xyz/tokens/USDV.svg
Chain: Hyperliquid
Coingecko ID (leave empty if not listed): delpho-usdv
Coinmarketcap ID (leave empty if not listed):
Short Description: USDV is an overcollateralized stablecoin minted against supported crypto collateral on Delpho, a CDP protocol on HyperEVM.

mintRedeemDescription: Users deposit supported collateral into the Delpho vault to mint USDV, currently at 0% interest. Borrowers can withdraw collateral or fully repay to close their position, as long as they stay above the liquidation threshold.

Token address and ticker: 0x8c6EB3C8d1FdDC752684274Fb4A3EB98DBE9cd26 — USDV

pegType: peggedUSD
pegMechanism: crypto-backed (overcollateralized)

priceSource: Open redemption mechanism (USDV redeemable directly for underlying collateral); secondary market: Nest MetaDEX ([usenest.xyz](http://usenest.xyz/))

wiki:
Twitter Link: https://x.com/delpho_labs
List of audit links if any: https://sherlock-files.ams3.digitaloceanspaces.com/reports/2026.07.01%20-%20Final%20-%20Delpho%20Collaborative%20Audit%20Report%201782919020.pdf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking Delpho USDV pegged-asset issuance on Hyperliquid.
  * Added minted and unreleased issuance data using token supply at a specified block.
  * Converted USDV’s six-decimal supply values into USD amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->