### PR TITLE
Add SoFiUSD (SOFID) fiat-backed pegged asset listing.

### DIFF
--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -12952,7 +12952,8 @@ export default [
     url: "https://www.sofi.com/crypto/sofiusd/",
     description:
       "SOFID is a U.S. dollar stablecoin issued by SoFi Bank, N.A., a nationally chartered U.S. bank. It is designed to enable 24/7 settlement and programmable dollar movement while operating within the U.S. banking regulatory framework.",
-    mintRedeemDescription: null,
+    mintRedeemDescription:
+      "SOFID is issued by SoFi Bank, N.A. and is intended to be redeemable 1:1 for U.S. dollars through supported SoFi channels.",
     onCoinGecko: "true",
     gecko_id: "sofiusd",
     cmcId: null,

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -12944,4 +12944,34 @@ export default [
     wiki: "https://krw1.kr/pdf/BDACS_KRW1_White%20Paper_EN.pdf",
     module: "krw1",
   },
+  {
+    id: "430",
+    name: "SoFiUSD",
+    address: "0x0cb6d03b0ac88a463f67b7ad99f9f3ec4678092e",
+    symbol: "SOFID",
+    url: "https://www.sofi.com/crypto/sofiusd/",
+    description:
+      "SOFID is a U.S. dollar stablecoin issued by SoFi Bank, N.A., a nationally chartered U.S. bank. It is designed to enable 24/7 settlement and programmable dollar movement while operating within the U.S. banking regulatory framework.",
+    mintRedeemDescription: null,
+    onCoinGecko: "true",
+    gecko_id: "sofiusd",
+    cmcId: null,
+    pegType: "peggedUSD",
+    pegMechanism: "fiat-backed",
+    priceSource: "coingecko",
+    auditLinks: null,
+    twitter: "https://x.com/SoFi",
+    wiki: null,
+    chainConfig: {
+      decimals: 6,
+      chains: {
+        ethereum: {
+          issued: ["0x0cb6d03b0ac88a463f67b7ad99f9f3ec4678092e"],
+        },
+        solana: {
+          issued: ["APhcqtzE73es3KAGiVksZFMLGwJDiAey5qZKUrQHEHfS"],
+        },
+      },
+    },
+  },
 ] as PeggedAsset[];


### PR DESCRIPTION
List native issuance on Ethereum and Solana with CoinGecko pricing until on-chain liquidity is sufficient.

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.


---
(fill in below form only for new listings)

##### Name (to be shown on DefiLlama):
SoFiUSD
##### Website Link:
https://www.sofi.com/crypto/sofiusd/
##### Logo (High resolution, will be shown with rounded borders):
https://stablecoins.bitgo.com/sofid-solana/sofid.svg
##### Chain:
Ethereum, Solana
##### Coingecko ID:
sofiusd
##### Coinmarketcap ID:
##### Short Description:
SOFID is a U.S. dollar stablecoin issued by SoFi Bank, N.A., a nationally chartered U.S. bank. It is designed to enable 24/7 settlement and programmable dollar movement while operating within the U.S. banking regulatory framework.
##### mintRedeemDescription:
##### Token address and ticker:
- Ethereum: `0x0cb6d03b0ac88a463f67b7ad99f9f3ec4678092e` (SOFID)
- Solana: `APhcqtzE73es3KAGiVksZFMLGwJDiAey5qZKUrQHEHfS` (SOFID)
##### pegType:
peggedUSD
##### pegMechanism:
fiat-backed
##### priceSource:
coingecko
##### wiki:
##### Twitter Link:
https://x.com/SoFi
##### List of audit links if any:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SoFiUSD stablecoin support, including USD-backed classification, pricing data, precision, and token addresses on Ethereum and Solana.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->