### PR TITLE
usd-somnia: remove doublecounted flag

### DIFF
--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -11329,7 +11329,6 @@ export default [
     twitter: "https://x.com/Somnia_Network",
     wiki: null,
     module: "usd-somnia",
-    doublecounted: true,
     chainConfig: {
       decimals: 18,
       chains: {


### PR DESCRIPTION
USDso (id 378) is currently flagged `doublecounted: true`, which excludes its $1.3M circulating from Somnia's chain-level stablecoin totals. As a result the Somnia chain page shows only the bridged USDC.e/USDT (~$367K) as Stablecoins Mcap, while the chain actually has ~$1.69M total circulating (stablecoins.llama.fi/stablecoincharts/Somnia).

The flag would be correct if the backing frxUSD were also tracked on Somnia, but it is not: the frax / frax-usd adapters have no Somnia config and frxUSD's chain list does not include Somnia. So nothing else represents this supply and the flag causes an undercount rather than preventing a double count.

USDso is minted 1:1 against frxUSD held in a Frax-operated BrandedCustodian vault on Somnia (as described in the entry's own mintRedeemDescription); the vaulted frxUSD is not separately counted anywhere on DefiLlama.

If frxUSD tracking is ever added for Somnia later, the vaulted collateral would be the appropriate place to exclude instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the USD Somnia asset configuration by removing an outdated double-counting designation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->