### PR TITLE
Add Polygon, Monad, and Tempo chains to SoFiUSD (SOFID)

### DIFF
--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -12972,6 +12972,15 @@ export default [
         solana: {
           issued: ["APhcqtzE73es3KAGiVksZFMLGwJDiAey5qZKUrQHEHfS"],
         },
+        polygon: {
+          issued: ["0x0cb6d03b0ac88a463f67b7ad99f9f3ec4678092e"],
+        },
+        monad: {
+          issued: ["0x0cb6d03b0ac88a463f67b7ad99f9f3ec4678092e"],
+        },
+        tempo: {
+          issued: ["0x20c00000000000000000000050f1d06232a0290f"],
+        },
       },
     },
   },


### PR DESCRIPTION
Adds three additional chains to the existing SoFiUSD (SOFID, id `430`) listing. Not a new listing, so the new-listing form below isn't filled in.

#### Chains added

| Chain | Address |
| --- | --- |
| Polygon | `0x0cb6d03b0ac88a463f67b7ad99f9f3ec4678092e` |
| Monad | `0x0cb6d03b0ac88a463f67b7ad99f9f3ec4678092e` |
| Tempo | `0x20c00000000000000000000050f1d06232a0290f` |

SoFiUSD is defined declaratively via `chainConfig`, so this is a 9-line change to `peggedData.ts` with no adapter file needed. All three chain keys already exist in the SDK provider list and in `helper/chains.json`.

#### Native issuance, not bridged

Each chain uses `issued` rather than `bridgedFromETH`, because SOFID is natively deployed on all three rather than bridged from Ethereum. Verified by probing the contracts: none expose a LayerZero endpoint, `oftVersion`, or a wrapped-token getter, and there is no lockbox on the Ethereum side. Polygon and Monad are byte-identical 170-byte proxies at the same address under the same owner (`0x571AFf...20D8`), consistent with a deterministic multi-chain deployment. Tempo is a predeploy exposing `currency() = "USD"`.

#### Verification

All four contracts report `name=SoFiUSD`, `symbol=SOFID`, `decimals=6`, matching the existing `decimals: 6` config.

`npx ts-node src/adapters/peggedAssets/test.ts src/adapters/peggedAssets/430 peggedUSD` passes against live RPCs with no extrapolation or cache fallback, confirming multicall works on both Monad and Tempo:

```
tempo     minted 0.00        monad    minted 0.00      polygon  minted 0.00
ethereum  minted 100.08 M    solana   minted 211.95 M
Total circulating 312.03 M
```

Supply is currently **zero on all three new chains** — they are deployed but not yet minted, so totals are unchanged for now and will populate as SoFi mints on each chain.

Typecheck shows no new errors; the errors `tsc` does emit are pre-existing and unrelated (the `starknet` package's bundled types, the `bob` adapter, and test files missing jest types).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SoFiUSD support for the Polygon, Monad, and Tempo networks.
  * Included the corresponding issued token addresses for each network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->