### PR TITLE
Change old USDT (by TomoBridge) to USDT (by Arken)

### DIFF
--- a/src/adapters/peggedAssets/tether/config.ts
+++ b/src/adapters/peggedAssets/tether/config.ts
@@ -97,8 +97,8 @@ export const chainContracts: ChainContracts = {
     bridgedFromETH: ["0xB44a9B6905aF7c801311e8F4E76932ee959c663C"], // multichain
   },
   tomochain: {
-    bridgedFromETH: ["0x69b946132b4a6c74cd29ba3ff614ceea1ef9ff2b"],
-    bridgedFromETH2: ["0x381b31409e4d220919b2cff012ed94d70135a59e"]
+    bridgedFromETH: ["0x69b946132b4a6c74cd29ba3ff614ceea1ef9ff2b"], // Arken USDT
+    // bridgedFromETH2: ["0x381b31409e4d220919b2cff012ed94d70135a59e"] // Tomobridge USDT, Multichain Bridge exploit.
   },
   harmony: {
     bridgeOnETH: ["0x2dccdb493827e15a5dc8f8b72147e6c4a5620857"],

--- a/src/adapters/peggedAssets/tether/index.ts
+++ b/src/adapters/peggedAssets/tether/index.ts
@@ -147,7 +147,6 @@ async function solanaUnreleased() {
       );
       totalUnreleased += unreleased;
     }
-
     sumSingleBalance(balances, "peggedUSD", totalUnreleased);
     return balances;
   };
@@ -216,7 +215,7 @@ async function algorandMinted() {
       async (_bail: any) =>
         await axios.get("https://mainnet-idx.algonode.cloud/v2/assets/312769")
     );
-    const supply = supplyRes.data.asset.params.total;
+    const supply = res.data.asset.params.total;
     const reserveRes = await retry(
       async (_bail: any) =>
         await axios.get(
@@ -752,7 +751,13 @@ const adapter: PeggedIssuanceAdapter = {
     ethereum: bridgedSupply("iotex", 6, chainContracts.iotex.bridgedFromETH),
   },
   tomochain: {
-    ethereum: bridgedSupply("tomochain", 6, chainContracts.tomochain.bridgedFromETH2),
+    ethereum: bridgedSupply(
+      "tomochain",
+      6,
+      chainContracts.tomochain.bridgedFromETH,
+      "tomochain",
+      "Ethereum"
+    ),
   },
   kardia: {
     ethereum: bridgedSupply("kardia", 6, chainContracts.kardia.bridgedFromETH),

--- a/src/adapters/peggedAssets/tether/index.ts
+++ b/src/adapters/peggedAssets/tether/index.ts
@@ -147,6 +147,7 @@ async function solanaUnreleased() {
       );
       totalUnreleased += unreleased;
     }
+
     sumSingleBalance(balances, "peggedUSD", totalUnreleased);
     return balances;
   };
@@ -215,7 +216,7 @@ async function algorandMinted() {
       async (_bail: any) =>
         await axios.get("https://mainnet-idx.algonode.cloud/v2/assets/312769")
     );
-    const supply = res.data.asset.params.total;
+    const supply = supplyRes.data.asset.params.total;
     const reserveRes = await retry(
       async (_bail: any) =>
         await axios.get(


### PR DESCRIPTION
TomoBridge has shut down without an official announcement. It was impacted by the Multichain exploit.

Tokens such as TOMO, ETH, and USDT had utilized Multichain’s "co-mint" and routing solutions to address liquidity fragmentation. However, Multichain collapsed after its founder absconded with the funds. TomoChain has since rebranded and has absolutely no plans for compensation; consequently, the USDT issued by TomoBridge is completely worthless.

Therefore, this PR is created to remove the USDT supply issued by TomoBridge, which is now worthless and retain only the USDT supply issued by Arken (which remains fully operational).

Token to be removed: 0x381B31409e4D220919B2cFF012ED94d70135A59e (USDT by TomoBridge)

Token to be used: 0x69B946132B4a6C74cd29Ba3ff614cEEA1eF9fF2B (USDT by Arken)