### PR TITLE
volume: serve shared-ticker token charts as empty instead of merged (43 tickers, incl. USDV and PUSD)

### DIFF
--- a/api2/cron-task/storeVolumes.ts
+++ b/api2/cron-task/storeVolumes.ts
@@ -5,6 +5,7 @@
 import * as sdk from '@defillama/sdk';
 import { storeRouteData } from '../file-cache';
 import { chainCacheSlug } from '../utils/cachePath';
+import peggedAssets from '../../src/peggedData/peggedData';
 
 interface DailyVolume {
   timestamp: number;
@@ -15,6 +16,28 @@ interface DailyVolume {
 }
 
 const R2_STORE_KEY = 'stablecoins/dailyVolumes';
+
+// The R2 volume cache keys tokens by ticker, not by stablecoin id, and it
+// uppercases them. 49 of the 416 entries in peggedData share a ticker with at
+// least one other, some with four others, so `volume/chart-token-<TICKER>` for
+// those is the sum of every coin using that ticker. There is no way to split it
+// back apart here: the per-coin figures are already added together by the time
+// this cron reads them.
+//
+// Serve those as empty rather than attributing one coin's chart to another.
+const ambiguousTokenKeys: Set<string> = (() => {
+  const counts: Record<string, number> = {};
+  for (const asset of peggedAssets as Array<any>) {
+    const symbol = typeof asset?.symbol === 'string' ? asset.symbol.toUpperCase() : '';
+    if (!symbol) continue;
+    counts[symbol] = (counts[symbol] ?? 0) + 1;
+  }
+  return new Set(Object.keys(counts).filter((symbol) => counts[symbol] > 1));
+})();
+
+const isAmbiguousTokenKey = (token: string) =>
+  ambiguousTokenKeys.has(String(token).toUpperCase());
+
 export async function storeVolumesRoutes() {
   const r2stablecoinVolumeCache: Record<string, DailyVolume> = await sdk.cache.readCache(R2_STORE_KEY, { readFromR2Cache: true });
   
@@ -134,12 +157,17 @@ export async function storeVolumesRoutes() {
     }
   }
 
+  const skippedTokenKeys: Array<string> = [];
   for (const [token, chartItems] of Object.entries(chartTokenTotal)) {
-    await storeRouteData(`volume/chart-token-${token}`, sortByFirstItemIsNumber(chartItems));
+    const ambiguous = isAmbiguousTokenKey(token);
+    if (ambiguous) skippedTokenKeys.push(token);
+    await storeRouteData(`volume/chart-token-${token}`, ambiguous ? [] : sortByFirstItemIsNumber(chartItems));
   }
   for (const [token, chartItems] of Object.entries(chartTokenChainBreakdownTotal)) {
-    await storeRouteData(`volume/chart-token-${token}-chain-breakdown`, sortByFirstItemIsNumber(chartItems));
+    await storeRouteData(`volume/chart-token-${token}-chain-breakdown`, isAmbiguousTokenKey(token) ? [] : sortByFirstItemIsNumber(chartItems));
   }
+  if (skippedTokenKeys.length)
+    console.log(`volume: served ${skippedTokenKeys.length} shared-ticker token charts as empty: ${skippedTokenKeys.sort().join(', ')}`);
   
   console.log('stored volume cache from R2'); 
   


### PR DESCRIPTION
Addresses #892, and the volume half of #690.

## The problem

The R2 volume cache keys tokens by **ticker**, not by stablecoin id, and uppercases them. `storeVolumes.ts` writes one `volume/chart-token-<TICKER>` route per key, so for any ticker shared by more than one stablecoin the route is the sum of all of them.

Reading `stablecoins/dailyVolumes` from R2 directly confirms the keys are tickers — 355 of them, all symbols: `PAXG, USDT, IDRT, TUSD, DAI, XSGD, SUSD, USDC, TRYB, MUSD, GUSD, EURS, HUSD, XCHF, BUSD, FRAX, …`

**49 of the 416 entries in `peggedData` share a ticker with at least one other**, several with four others. From outside, on #892's ticker:

```
GET https://stablecoins.llama.fi/chart/volume/token/USDV
  928 points, first 2023-09-13, max $85,297,230
```

Four stablecoins share `USDV`:

| id | name | gecko_id |
|---|---|---|
| 143 | Verified USD | verified-usd-foundation-usdv |
| 261 | Solomon USDv | solomon-usdv |
| 398 | Valtorum USD | valtorum-usdv |
| 431 | Delpho USDV | delpho-usdv |

Delpho has only existed since ~Aug 2026, so nearly all of that series belongs to the other three, and the same merged chart is served on all four coins' pages. `PUSD` in #690 is the same shape across five coins, one of them Palm USD.

## What this does

The per-coin figures are already summed by the time this cron reads them, so nothing here can split them apart. This serves the affected routes as `[]` instead, so a page shows no volume rather than another coin's.

Ambiguity is computed from `peggedData` at module load, uppercased to match the cache keys. The comparison is case-insensitive on purpose: **86 of the 416 symbols are not all-uppercase** (`USDm`, `crvUSD`, `eUSD`, `sUSD`) while the cache keys are. It logs which tickers were emptied, so the list shows up in cron output instead of being silent.

## Verification

Ran the cron against the live R2 cache. **43** tickers emptied, the 49 shared ones minus 6 that have no volume data at all:

```
volume: served 43 shared-ticker token charts as empty: AUSD, BOLD, BTCUSD, BUSD,
CASH, CUSD, EUSD, FUSD, GUSD, HYUSD, IUSD, MONEY, MSUSD, MUSD, PUSD, REUSD, RUSD,
SUSD, USC, USD+, USDA, USDAF, USDB, USDE, USDF, USDH, USDK, USDL, USDM, USDN,
USDP, USDQ, USDR, USDS, USDU, USDV, USDX, USH, USN, USP, USX, XUSD, YUSD
```

Then checked the written route files. 86 of 825 are empty, being those 43 across both the total and chain-breakdown routes, and unshared tickers are untouched:

| route | before | after |
|---|---|---|
| `chart-token-USDV` | 928 pts, max $85.3M | **`[]`** |
| `chart-token-USDV-chain-breakdown` | populated | **`[]`** |
| `chart-token-PUSD` | populated | **`[]`** |
| `chart-token-USDT` | — | 2053 pts, max 49,538,822,127 |
| `chart-token-DAI` | — | 2053 pts, max 7,398,011,733 |
| `chart-token-FRAX` | — | 2053 pts, max 522,249,316 |
| `chart-token-PAXG` | — | 2053 pts, max 163,298,418 |

Typecheck unchanged: 47 pre-existing errors before and after (`node_modules/starknet` .d.ts, the `bob` adapter, missing test runner types), none in this file.

## Being explicit about the tradeoff

This **removes data users can currently see**, which is a judgement call rather than a pure bug fix, and I would not have sent it unprompted. Serving `[]` says "we cannot attribute this" instead of showing a number that belongs to other coins.

The real fix is for whatever writes `stablecoins/dailyVolumes` to key by stablecoin id or gecko_id. After that this guard stops matching anything by itself and can be deleted. Reverting in the meantime is a one-line change.

## Deliberately out of scope

The aggregate token-breakdown routes (`chart-total-token-breakdown` and the per-chain ones) are left alone. They describe a distribution across tickers rather than attributing a series to one coin, so a merged bucket there is mislabelled but not misattributed, and emptying it would silently drop volume out of the totals.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented charts for ticker symbols shared by multiple stablecoins from displaying potentially misleading aggregated data.
  * Ambiguous ticker symbols now show empty chart results instead of incorrect breakdowns.
  * Added logging for skipped ambiguous tickers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->