### PR TITLE
hrusd: exclude undistributed staking rewards from circulating supply

### DIFF
--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -13074,6 +13074,10 @@ export default [
       chains: {
         base: {
           issued: ["0x5587AD03F9565F1B86cfA51a3C744Bcc4039dAf0"],
+          unreleased: [
+            "0xb72f376ae7732a76F1C18e0547553A616a33a2bd",
+            "0xA61C08DeC414416E55de7b4510bA8Ef25C89886a",
+          ],
         },
       },
     },


### PR DESCRIPTION
Small follow-up to `a06e4f2` ("add hrusd listing"), which landed the HRUSD entry while this
PR was open. This branch is now rebased onto that commit and carries only one change.

### What this fixes

`circulating` currently equals `minted`, because no `unreleased` addresses are configured.
511.83 HRUSD sit in the two V3LPStakingRewards contracts as protocol-funded reward
inventory that has never been distributed to a holder:

| Contract | HRUSD held |
|---|---|
| `0xb72f376ae7732a76F1C18e0547553A616a33a2bd` (legacy) | 193.04 |
| `0xA61C08DeC414416E55de7b4510bA8Ef25C89886a` (current) | 318.80 |

On the current deployment `availableRewards()` reads 318.80 against `totalOwed()` of 0 —
nothing is owed to any staker yet, so none of it is circulating. Counting it inflates
circulating supply by ~1.6% today, and by more as the protocol tops the reward pool up.

### Diff

Four lines, adding `unreleased` alongside the existing `issued` in the Base chain config.

### Validation

Before, on `a06e4f2` as it stands:

```
$ npx ts-node --transpile-only test.ts 433 peggedUSD

--- base ---
minted                    32.17 k
circulating               32.17 k
Total unreleased          0.00
```

After:

```
$ npx ts-node --transpile-only test.ts 433 peggedUSD

--- base ---
minted                    32.17 k
circulating               31.66 k
unreleased                511.83

------ NO EXTRAPOLATION ------
✅ All chains used real-time data
```

`minted` is unchanged; only the undistributed inventory moves out of `circulating`.
`tsc --noEmit` reports no errors in `peggedData.ts`. No dependencies added, no lockfile
changes, no other entry touched.

### On the rest of the entry

Everything else in `a06e4f2` is left exactly as you wrote it, including `gecko_id: "hrusd"`
with `onCoinGecko: "false"` — that matches the convention used by 29 other entries, and the
field doubles as the internal unique id, so it is not something this PR touches. Decimals are
read on-chain by the helper, so the absence of `chainConfig.decimals` is likewise fine; the
test above confirms `minted` resolves correctly at 6 decimals.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three Base network addresses to the HRUSD configuration, expanding support for upcoming token deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->