### PR TITLE
feat(usd-coin,eurc): native USDC on X Layer + Cronos, bridged USDC on Ink + Sui, native EURC on Cronos + World Chain

### DIFF
--- a/src/adapters/peggedAssets/eurc/index.ts
+++ b/src/adapters/peggedAssets/eurc/index.ts
@@ -26,6 +26,12 @@ const chainContracts: ChainContracts = {
   base: {
     issued: ["0x60a3e35cc302bfa44cb288bc5a4f316fdb1adb42"],
   },
+  cronos: {
+    issued: ["0xA6dE01a2d62C6B5f3525d768f34d276652C554c8"],
+  },
+  wc: {
+    issued: ["0x1C60ba0A0eD1019e8Eb035E6daF4155A5cE2380B"],
+  },
   solana: {
     issued: ["HzwqbKZw8HxMN6bF2yFZNrht3c2iXXzpKcFu7uBEDKtr"],
     unreleased: ["7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE"], 
@@ -170,6 +176,12 @@ const adapter: PeggedIssuanceAdapter = {
   },
   base: {
     minted: chainMinted("base", 6),
+  },
+  cronos: {
+    minted: chainMinted("cronos", 6),
+  },
+  wc: {
+    minted: chainMinted("wc", 6),
   },
   solana: {
     minted: solanaMintedOrBridged(chainContracts.solana.issued, "peggedEUR"),

--- a/src/adapters/peggedAssets/eurc/index.ts
+++ b/src/adapters/peggedAssets/eurc/index.ts
@@ -29,7 +29,7 @@ const chainContracts: ChainContracts = {
   cronos: {
     issued: ["0xA6dE01a2d62C6B5f3525d768f34d276652C554c8"],
   },
-  wc: {
+  wc: {  // World Chain (Wanchain is "wan")
     issued: ["0x1C60ba0A0eD1019e8Eb035E6daF4155A5cE2380B"],
   },
   solana: {
@@ -180,7 +180,7 @@ const adapter: PeggedIssuanceAdapter = {
   cronos: {
     minted: chainMinted("cronos", 6),
   },
-  wc: {
+  wc: {  // World Chain (Wanchain is "wan")
     minted: chainMinted("wc", 6),
   },
   solana: {

--- a/src/adapters/peggedAssets/usd-coin/config.ts
+++ b/src/adapters/peggedAssets/usd-coin/config.ts
@@ -460,7 +460,8 @@ export const chainContracts: ChainContracts = {
     bridgedFromETH: ["0xa4151b2b3e269645181dccf2d426ce75fcbdeca9"],
   },
   cronos: {
-    bridgedFromETH: ["0xc21223249ca28397b4b6541dffaecc539bff0c59"],
+    issued: ["0x3D7F2C478aAfdB65542BCB44bCeeC05849999d2D"], // Circle-issued native USDC
+    bridgedFromETH: ["0xc21223249ca28397b4b6541dffaecc539bff0c59"], // USDC.e, not Circle-issued
   },
   bsquared: {
     bridgedFromETH: ["0xE544e8a38aDD9B1ABF21922090445Ba93f74B9E5"],
@@ -470,6 +471,7 @@ export const chainContracts: ChainContracts = {
   },
   ink: {
     issued: ["0x2D270e6886d130D724215A266106e6832161EAEd"],
+    bridgedFromETH: ["0xF1815bd50389c46847f0Bda824eC8da914045D14"], // Bridged USDC (Stargate)
   },
   sei: {
     bridgedFromNoble: ["0x3894085Ef7Ff0f0aeDf52E2A2704928d1Ec074F1"]
@@ -483,7 +485,8 @@ export const chainContracts: ChainContracts = {
     bridgedFromETH: ["0xDF0B24095e15044538866576754F3C964e902Ee6"],
   },
   xlayer: {
-    bridgedFromETH: ["0x74b7f16337b8972027f6196a17a631ac6de26d22"],
+    issued: ["0xB6CEceAB302E2E4948951eE7843FC24E92933061"], // Circle-issued native USDC
+    bridgedFromETH: ["0x74b7f16337b8972027f6196a17a631ac6de26d22"], // USDC.e, not Circle-issued
   },
   move: {
     bridgedFromETH: ["0x83121c9f9b0527d1f056e21a950d6bf3b9e9e2e8353d0e95ccea726713cbea39"], // oft native bridge

--- a/src/adapters/peggedAssets/usd-coin/index.ts
+++ b/src/adapters/peggedAssets/usd-coin/index.ts
@@ -231,6 +231,33 @@ async function suiBridged(chain: string) {
   };
 }
 
+// Wormhole keeps a wrapped coin's TreasuryCap inside the token bridge's WrappedAsset, so
+// coinMetadata (and the decommissioned suix_getTotalSupply) don't expose its supply. The
+// WrappedAsset is a dynamic field on the token registry, which is the `token_registry` field
+// of the bridge state object 0xc57508ee0d4595e5a8728974a4a93a787d38f339757230d441e895422c07aba9.
+// Same approach as the Wormhole USDT reader in the tether adapter.
+const SUI_WORMHOLE_TOKEN_BRIDGE =
+  "0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d";
+const SUI_WORMHOLE_TOKEN_REGISTRY =
+  "0x334881831bd89287554a6121087e498fa023ce52c037001b53a4563a00a281a5";
+const SUI_WORMHOLE_USDC =
+  "0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf";
+
+async function suiWormholeBridged(): Promise<Balances> {
+  let balances = {} as Balances;
+  const wrappedAsset = await sui.getDynamicFieldObject(
+    SUI_WORMHOLE_TOKEN_REGISTRY,
+    `${SUI_WORMHOLE_TOKEN_BRIDGE}::token_registry::Key<${SUI_WORMHOLE_USDC}::coin::COIN>`
+  );
+  // GraphQL returns the Move value as plain nested JSON, without JSON-RPC's `fields` wrappers.
+  const wrapped = wrappedAsset?.fields?.value ?? wrappedAsset?.fields;
+  if (!wrapped) throw new Error("sui: wormhole USDC WrappedAsset not found");
+  const totalSupply =
+    Number(wrapped.treasury_cap.total_supply.value) / 10 ** Number(wrapped.decimals);
+  sumSingleBalance(balances, "peggedUSD", totalSupply, SUI_WORMHOLE_USDC, true);
+  return balances;
+}
+
 async function reinetworkBridged(address: string, decimals: number) {
   return async function () {
     let balances = {} as Balances;
@@ -894,7 +921,7 @@ const adapter: PeggedIssuanceAdapter = {
   },
   sui: {
     minted: suiMinted,
-    ethereum: suiBridged("ETH"),
+    ethereum: suiWormholeBridged,
     bsc: suiBridged("BSC"),
     solana: suiBridged("SOLANA"),
     arbitrum: suiBridged("ARBITRUM_BRIDGED"),
@@ -1026,6 +1053,7 @@ const adapter: PeggedIssuanceAdapter = {
     ethereum: bridgedSupply("core", 6, chainContracts.core.bridgedFromETH),
   },
   cronos: {
+    minted: chainMinted("cronos", 6),
     ethereum: bridgedSupply("cronos", 6, chainContracts.cronos.bridgedFromETH),
   },
   bsquared: {
@@ -1036,6 +1064,7 @@ const adapter: PeggedIssuanceAdapter = {
   },
   ink: {
     minted: chainMinted("ink", 6),
+    ethereum: bridgedSupply("ink", 6, chainContracts.ink.bridgedFromETH),
   },
   nibiru: {
     ethereum: nibiruBridged(),
@@ -1048,6 +1077,7 @@ const adapter: PeggedIssuanceAdapter = {
     ethereum: bridgedSupply("corn", 6, chainContracts.corn.bridgedFromETH),
   },
   xlayer: {
+    minted: chainMinted("xlayer", 6),
     ethereum: bridgedSupply("xlayer", 6, chainContracts.xlayer.bridgedFromETH),
   },
   xdc: {


### PR DESCRIPTION
## What

Fills six Circle-related gaps in the USDC / EURC adapters. Native and bridged are already separate (`issued` / `minted` vs `bridgedFromETH` / `ethereum`); this does not change the schema. All values below were read on-chain on 2026-08-20 and confirmed by the adapter test output at the bottom.

### USDC (`usd-coin`)

| Chain | Change | Why |
|---|---|---|
| **X Layer** | add `issued` + `minted` next to existing USDC.e | Circle-issued native is `0xB6CEceAB302E2E4948951eE7843FC24E92933061` (`totalSupply` 11.12M). The address already in config is bridged USDC.e (1.78M), which Circle documents as not Circle-issued, so `totalMintedUSD` read as 0. |
| **Cronos** | add `issued` + `minted` next to existing USDC.e | Native `0x3D7F2C478aAfdB65542BCB44bCeeC05849999d2D` (`totalSupply` 4.17M). Existing `0xc212…` is USDC.e (179.45M), so the chain currently looks 100% bridged. |
| **Ink** | add Stargate USDC.e `bridgedFromETH` | Native already tracked (27.20M). Bridged `0xF1815bd50389c46847f0Bda824eC8da914045D14` (`symbol` USDC.e, `totalSupply` 258.95k) was missing. Same Stargate CREATE2 address already listed for Flow in this adapter. |
| **Sui** | read Wormhole wUSDC from the token bridge `WrappedAsset` | Native already tracked (297.95M). `suiBridged("ETH")` contributed 0 — the AWS endpoint it calls (`kx58j6x5me…/sui/usdc`) currently returns `{"error":"Internal Server Error"}`. Now reads 3.35M. |

**On the Sui approach:** `sui.getTokenSupply` does *not* work for this coin. Sui's `coinMetadata` returns `supply: null` for `0x5d4b3025…::coin::COIN`, because Wormhole holds the wrapped coin's `TreasuryCap` inside the token bridge's `WrappedAsset` rather than exposing it as a normal supply. Using `getTokenSupply` here would silently divide `null` and report **$0**. This PR instead reads the `WrappedAsset` dynamic field off the token registry via `sui.getDynamicFieldObject` — the same approach the `tether` adapter already uses for Wormhole USDT.

The `bsc` / `solana` / `arbitrum` Sui paths are left as-is and remain out of scope, but note they hit the same 500-ing AWS endpoint and currently report 0.

Not in this PR: Arc (Circle has not published a mainnet USDC address).

### EURC (`eurc`)

| Chain | Change | Why |
|---|---|---|
| **Cronos** | add `issued` + `minted` | `0xA6dE01a2d62C6B5f3525d768f34d276652C554c8`, live CRC-20 EURC, `totalSupply` 159.57k. Chain was absent from the adapter. |
| **World Chain** | add `issued` + `minted` on chain key `wc` | `0x1C60ba0A0eD1019e8Eb035E6daF4155A5cE2380B`, `totalSupply` 412.49k. Uses the same `wc` key already used for native USDC in this repo. |

EURCV is out of scope: SG-FORGE's four documented public chains (Ethereum, Solana, XRPL, Stellar) are already in `peggedData.ts` `chainConfig` for id 254.

No `normalizeChain.ts` changes and no new chain slugs: `xlayer`, `cronos`, `ink`, `sui` and `wc` are all existing `@defillama/sdk` chain keys already used by the USDC adapter (`World Chain` -> `wc` via `getChainKeyFromLabel`).

Addresses from [USDC contract addresses](https://developers.circle.com/stablecoins/usdc-contract-addresses) and [EURC contract addresses](https://developers.circle.com/stablecoins/eurc-contract-addresses).

## Test plan

`npx ts-node test usd-coin/index peggedUSD`:

```
xlayer     minted 11.12 M   ethereum 1.78 M
cronos     minted 4.17 M    ethereum 179.45 M
ink        minted 27.20 M   ethereum 258.95 k
sui        minted 297.95 M  ethereum 3.35 M
```

`npx ts-node test eurc/index peggedEUR`:

```
cronos     minted 159.57 k
wc         minted 412.49 k
```

Both runs report `✅ All chains used real-time data`, and no previously-tracked chain changed. Native and bridged addresses on X Layer / Cronos / Ink are distinct contracts, so there is no double count.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added EURC supply tracking for Cronos and Wanchain, including minted supply reporting with six-decimal precision.
  * Added support for native USDC on Cronos and XLayer.
  * Added support for bridged USDC on Ink and Sui.
  * Improved USDC supply reporting across Ethereum, Sui, Cronos, XLayer, and Ink by distinguishing native and bridged token supplies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->