### PR TITLE
Add UST1 unstablecoin (Terra Classic)

### DIFF
--- a/src/adapters/peggedAssets/ust1/index.ts
+++ b/src/adapters/peggedAssets/ust1/index.ts
@@ -1,0 +1,37 @@
+const axios = require("axios");
+const retry = require("async-retry");
+import { sumSingleBalance } from "../helper/generalUtil";
+import { Balances, PeggedIssuanceAdapter } from "../peggedAsset.type";
+
+/**
+ * UST1 unstablecoin on Terra Classic.
+ * Circulating = CW20 token_info.total_supply / 1e6 (human). peggedUSD.
+ * Mechanism: crypto-backed (ust1-window vs vFDUSD). Do not hardcode $1.
+ */
+
+const UST1 = "terra1f0eqgy9w7e5e7up97vjudqwx38tesf8ylx75x2lv3nwm0clry0pqmgfy72";
+const UST1_DECIMALS = 6;
+const TERRA_LCD = "https://terra-classic-lcd.publicnode.com";
+
+async function terraMinted() {
+  const query = Buffer.from(JSON.stringify({ token_info: {} })).toString("base64");
+  const url = `${TERRA_LCD}/cosmwasm/wasm/v1/contract/${UST1}/smart/${query}`;
+  const res = await retry(async (_bail: any) => await axios.get(url));
+  const raw = res?.data?.data?.total_supply;
+  const n = Number(raw);
+  if (raw == null || raw === "" || !Number.isFinite(n) || n < 0) {
+    throw new Error("UST1 token_info.total_supply missing or invalid");
+  }
+  const balances = {} as Balances;
+  sumSingleBalance(balances, "peggedUSD", n / 10 ** UST1_DECIMALS, "issued", false);
+  return balances;
+}
+
+const adapter: PeggedIssuanceAdapter = {
+  terra: {
+    minted: terraMinted,
+    unreleased: async () => ({}),
+  },
+};
+
+export default adapter;

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -13107,4 +13107,24 @@ export default [
       },
     },
   },
+  {
+    id: "435",
+    name: "UST1",
+    address: "terra1f0eqgy9w7e5e7up97vjudqwx38tesf8ylx75x2lv3nwm0clry0pqmgfy72",
+    symbol: "UST1",
+    url: "https://dex.cl8y.com",
+    description:
+      "UST1 is an unstablecoin on Terra Classic. It targets USD via the ust1-window against vFDUSD (crypto-backed). Circulating supply is the CW20 total_supply. Price is market / Llama — not hardcoded to $1.",
+    mintRedeemDescription:
+      "Mint and redeem through the ust1-window oracle against vFDUSD. Secondary AMM price can deviate from the window rate.",
+    onCoinGecko: "false",
+    gecko_id: "ust1",
+    cmcId: null,
+    pegType: "peggedUSD",
+    pegMechanism: "crypto-backed",
+    priceSource: "defillama",
+    twitter: "",
+    wiki: "https://gitlab.com/PlasticDigits/cl8y-dex-terraclassic/-/blob/main/docs/DEFILLAMA.md",
+    module: "ust1",
+  },
 ] as PeggedAsset[];

--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -13196,7 +13196,7 @@ export default [
     module: "anchorpoint-hkd-at-par",
   },
   {
-    id: "435",
+    id: "438",
     name: "UST1",
     address: "terra1f0eqgy9w7e5e7up97vjudqwx38tesf8ylx75x2lv3nwm0clry0pqmgfy72",
     symbol: "UST1",


### PR DESCRIPTION
## Summary

Add **UST1** to Llama Stablecoins as an **unstablecoin** on Terra Classic (`terra`).

- Product name is **unstablecoin**: USD-target via the ust1-window against vFDUSD, but the window rate and secondary AMM can deviate.
- `pegType`: `peggedUSD`
- `pegMechanism`: crypto-backed (ust1-window vs vFDUSD)
- Circulating = on-chain CW20 `token_info.total_supply` / 1e6
- Price is market / Llama — **never hardcoded to $1**
- Website: https://dex.cl8y.com
- CW20: `terra1f0eqgy9w7e5e7up97vjudqwx38tesf8ylx75x2lv3nwm0clry0pqmgfy72`

USTR is **not** listed here (reserve token, not a stablecoin).

Related CL8Y DEX TVL adapter: https://github.com/DefiLlama/DefiLlama-Adapters/pull/20676

## Test

```
npx ts-node --transpile-only test.ts ust1 peggedUSD
```

LCD `token_info` at submit time: `total_supply` 26095100139 → **26095.100139** human UST1.

Discord metadata (ticker / icon) can follow per the README after review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking Terra Classic’s UST1 stablecoin.
  * Displays UST1’s USD-pegged classification, market-based pricing, documentation, and mint/redeem details.
  * Reports issued UST1 balances from on-chain supply data, with improved handling for temporary network issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->