### PR TITLE
Track bridged USDC (USDC.e) on RISE Chain

### DIFF
--- a/src/adapters/peggedAssets/usd-coin/config.ts
+++ b/src/adapters/peggedAssets/usd-coin/config.ts
@@ -565,5 +565,9 @@ export const chainContracts: ChainContracts = {
     bridgedFromArbitrum: [
       "factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1lmcfftadjkt4gt3lcvmz6qn4dhx59dv2m7yv8r", // Wormhole USDCarb
     ],
-  }
+  },
+  rise: {
+    // Circle Bridged USDC Standard (FiatTokenProxy), symbol USDC.e, name "Bridged USDC"
+    bridgedFromETH: ["0xe436820ba0C69702c1d3E601d421c0eF38262739"],
+  },
 };

--- a/src/adapters/peggedAssets/usd-coin/index.ts
+++ b/src/adapters/peggedAssets/usd-coin/index.ts
@@ -1139,6 +1139,9 @@ const adapter: PeggedIssuanceAdapter = {
   pharos: {
     minted: chainMinted("pharos", 6),
   },
+  rise: {
+    ethereum: bridgedSupply("rise", 6, chainContracts.rise.bridgedFromETH),
+  },
 };
 
 export default adapter;


### PR DESCRIPTION
Adds RISE Chain to the `usd-coin` adapter.

RISE has Circle's Bridged USDC Standard deployment — `FiatTokenProxy`, name "Bridged USDC", symbol USDC.e, 6 decimals — at `0xe436820ba0C69702c1d3E601d421c0eF38262739`, bridged from Ethereum. It currently holds ~19.7M supply that was not counted anywhere, so RISE's stablecoin mcap only showed USDR (~$2.69m, 100% dominance).

Same shape as the other bridged-only chains (scroll, taiko, lisk, zircuit).

Test:

```
$ npx ts-node --transpile-only src/adapters/peggedAssets/test.ts src/adapters/peggedAssets/usd-coin/index peggedUSD

--- rise ---
ethereum                  19.71 M
circulating               19.71 M
```

Summary table row:

```
│ 86 │ 'rise' │ '19.71 M' │ '19.71 M' │
```

Contract verified on https://explorer.risechain.com/address/0xe436820ba0C69702c1d3E601d421c0eF38262739


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking bridged USDC on the Rise network.
  * Reports the circulating supply of Ethereum-bridged USDC with the correct token precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->