### PR TITLE
eurc: Circle renamed EUROC to EURC, so the Stellar leg stopped resolving

### DIFF
--- a/src/adapters/peggedAssets/eurc/index.ts
+++ b/src/adapters/peggedAssets/eurc/index.ts
@@ -125,7 +125,7 @@ async function circleAPIChainMinted(chain: string) {
         await axios.get("https://api.circle.com/v1/stablecoins")
     );
     const eurcData = issuance.data.data.filter(
-      (obj: any) => obj.symbol === "EUROC"
+      (obj: any) => obj.symbol === "EURC"
     );
     const filteredChainsData = await eurcData[0].chains.filter(
       (obj: any) => obj.chain === chain


### PR DESCRIPTION
EURC on Stellar has reported nothing since 2026-08-25. The Stellar leg reads Circle's public issuance API and picks the euro stablecoin out of the response by symbol:

```ts
const eurcData = issuance.data.data.filter(
  (obj: any) => obj.symbol === "EUROC"
);
const filteredChainsData = await eurcData[0].chains.filter(...)
```

Circle renamed that symbol from `EUROC` to `EURC`. The filter now matches nothing, so `eurcData[0]` is `undefined` and the next line throws `TypeError: Cannot read properties of undefined (reading 'chains')`.

### When it changed

Archived responses from `https://api.circle.com/v1/stablecoins`:

| snapshot | symbol |
|---|---|
| 2026-07-01 19:44 UTC | `"symbol":"EUROC"` |
| 2026-08-26 07:25 UTC | `"symbol":"EURC"` |

That window contains 2026-08-25, the last day EURC/Stellar has a stored balance. The API itself is healthy — the `XLM` row carries `updateDate: 2026-08-31T19:02:01.850Z`.

### What is actually there

| source | EURC on Stellar |
|---|---:|
| Circle `/v1/stablecoins`, `XLM` row | 3,475,991.51 |
| Stellar Horizon, Circle's issuer `GDHU6WRG…NPP2` (held + claimable + pools + contracts) | 3,475,735.59 |
| DefiLlama today | **0** |

The two independent sources agree to 0.007%. At $1.16/EURC that is about $4.03M currently reported as zero.

### Before / after

Calling the Stellar leg directly on this branch:

```
BEFORE: stellar.minted() THREW: Cannot read properties of undefined (reading 'chains')
AFTER:  stellar.minted() => {"peggedEUR":3475991,"bridges":{"issued":{"not-found":{"amount":3475991}}}}
```

which lines up with the last healthy stored value (3,570,274 on 2026-08-25).

Only this one adapter is affected. `usd-coin/index.ts` has the same helper but filters on `symbol === "USDC"`, which Circle did not rename, so every USDC chain fed by that API (`XLM`, `HBAR`, `APTOS`, `NOBLE`, `PAH`, `SEI`, `EDGE`) is still resolving. The other `EUROC` occurrences in the repo are description and wiki text in `peggedData.ts`, not lookups.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated stablecoin filtering to recognize the current `EURC` symbol, improving accurate asset identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->