### PR TITLE
feat: add USDBridge on Tempo

### DIFF
--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -13216,4 +13216,31 @@ export default [
     module: "ust1",
     doublecounted: true,
   },
+  {
+    id: "439",
+    name: "USDBridge",
+    address: "tempo:0x20c0000000000000000000003158081efd85bfc2",
+    symbol: "USDB",
+    url: "https://www.bridge.xyz/",
+    description:
+      "USDB is a U.S. dollar-backed stablecoin issued and managed by Bridge.",
+    mintRedeemDescription:
+      "USDB is backed 1:1 by U.S. dollar-denominated reserve assets and can be exchanged for fiat or other stablecoins through Bridge's Orchestration APIs.",
+    onCoinGecko: "false",
+    gecko_id: null,
+    cmcId: null,
+    pegType: "peggedUSD",
+    pegMechanism: "fiat-backed",
+    priceSource: "defillama",
+    auditLinks: null,
+    twitter: "https://x.com/Stablecoin",
+    wiki: "https://apidocs.bridge.xyz/platform/issuance/usdb",
+    chainConfig: {
+      chains: {
+        tempo: {
+          issued: ["0x20c0000000000000000000003158081efd85bfc2"],
+        },
+      },
+    },
+  },
 ] as PeggedAsset[];


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
USDBridge

##### Website Link:
https://www.bridge.xyz/

##### Logo (High resolution, will be shown with rounded borders):

https://github.com/tempoxyz/tempo-apps/blob/main/apps/tokenlist/data/4217/icons/0x20c0000000000000000000003158081efd85bfc2.svg

##### Chain:
Tempo

##### Coingecko ID (leave empty if not listed):

##### Coinmarketcap ID (leave empty if not listed):

##### Short Description:
USDB is a U.S. dollar-backed stablecoin issued and managed by Bridge.

##### mintRedeemDescription:
USDB is backed 1:1 by U.S. dollar-denominated reserve assets and can be exchanged for fiat or other stablecoins through Bridge's Orchestration APIs.

##### Token address and ticker:
USDB — [0x20C0000000000000000000003158081EFd85bFc2](https://explore.tempo.xyz/address/0x20C0000000000000000000003158081EFd85bFc2?tab=token)

##### pegType:
peggedUSD

##### pegMechanism:
fiat-backed

##### priceSource:
defillama

##### wiki:
https://apidocs.bridge.xyz/platform/issuance/usdb

##### Twitter Link:
https://x.com/Stablecoin