### PR TITLE
feat: add Deel USD on Tempo

### DIFF
--- a/src/peggedData/peggedData.ts
+++ b/src/peggedData/peggedData.ts
@@ -13216,4 +13216,31 @@ export default [
     module: "ust1",
     doublecounted: true,
   },
+  {
+    id: "440",
+    name: "Deel USD",
+    address: "tempo:0x20c0000000000000000000006fD9A167923ba194",
+    symbol: "DLUSD",
+    url: "https://www.deel.com/",
+    description:
+      "DLUSD is Deel's U.S. dollar-denominated stablecoin for contractor payments, issued through Bridge's Open Issuance platform and settled on Tempo.",
+    mintRedeemDescription:
+      "Bridge converts employer U.S. dollar payments into DLUSD, which is designed to track the U.S. dollar 1:1 and is redeemable for U.S. dollar value within Deel.",
+    onCoinGecko: "false",
+    gecko_id: null,
+    cmcId: null,
+    pegType: "peggedUSD",
+    pegMechanism: "fiat-backed",
+    priceSource: "defillama",
+    auditLinks: null,
+    twitter: "https://x.com/deel",
+    wiki: "https://www.deel.com/blog/introducing-stablecoin-wallet/",
+    chainConfig: {
+      chains: {
+        tempo: {
+          issued: ["0x20c0000000000000000000006fD9A167923ba194"],
+        },
+      },
+    },
+  },
 ] as PeggedAsset[];


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
Deel USD

##### Website Link:
https://www.deel.com/

##### Logo (High resolution, will be shown with rounded borders):

https://github.com/tempoxyz/tempo-apps/blob/main/apps/tokenlist/data/4217/icons/0x20c0000000000000000000006fd9a167923ba194.png

##### Chain:
Tempo

##### Coingecko ID (leave empty if not listed):

##### Coinmarketcap ID (leave empty if not listed):

##### Short Description:
DLUSD is Deel's U.S. dollar-denominated stablecoin for contractor payments, issued through Bridge's Open Issuance platform and settled on Tempo.

##### mintRedeemDescription:
Bridge converts employer U.S. dollar payments into DLUSD, which is designed to track the U.S. dollar 1:1 and is redeemable for U.S. dollar value within Deel.

##### Token address and ticker:
DLUSD — [0x20C0000000000000000000006fD9A167923ba194](https://explore.tempo.xyz/address/0x20C0000000000000000000006fD9A167923ba194?tab=token)

##### pegType:
peggedUSD

##### pegMechanism:
fiat-backed

##### priceSource:
defillama

##### wiki:
https://www.deel.com/blog/introducing-stablecoin-wallet/

##### Twitter Link:
https://x.com/deel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the Deel USD (DLUSD) pegged asset.
  - Included its fiat-backed USD stablecoin details and availability on the Tempo network.
  - Added information indicating its use for contractor payments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->