### PR TITLE
Fix: ylds

### DIFF
--- a/src/adapters/peggedAssets/ylds/index.ts
+++ b/src/adapters/peggedAssets/ylds/index.ts
@@ -16,12 +16,10 @@ async function stellarMinted(assetID: string) {
     let balances = {} as Balances;
     const totalSupply = await stellarGetTotalSupply(assetID);
     sumSingleBalance(balances, "peggedUSD", totalSupply, "issued", false);
+    console.log("stellar", balances)
     return balances;
   };
 }
-
-const solanawYLDSContract = ['8fr7WGTVFszfyNWRMXj6fRjZZAnDwmXwEpCrtzmUkdih']
-const ethereumWYLDSContract = ['0x6aD038cA6C04e885630851278ca0a856Ad9a66Cc']
 
 const chainContracts = {
     stellar: {
@@ -32,18 +30,8 @@ const chainContracts = {
 // Use `addChainExports` to generate the final adapter with combined logic
 const adapter: PeggedIssuanceAdapter = {
     ...addChainExports(chainContracts),
-    ethereum: {
-        provenance: bridgedSupply('ethereum', 6, ethereumWYLDSContract)
-    },
-    provenance: {
-        minted: provenanceSupply(),
-    },
-    solana: {
-        provenance: solanaMintedOrBridged(solanawYLDSContract)
-    },
-    stellar: {
-        minted: stellarMinted(chainContracts.stellar.issued[0]),
-    },
+    provenance: { minted: provenanceSupply() },
+    stellar: { minted: stellarMinted(chainContracts.stellar.issued[0]) },
 };
 
 export default adapter;

--- a/src/adapters/peggedAssets/ylds/index.ts
+++ b/src/adapters/peggedAssets/ylds/index.ts
@@ -16,7 +16,6 @@ async function stellarMinted(assetID: string) {
     let balances = {} as Balances;
     const totalSupply = await stellarGetTotalSupply(assetID);
     sumSingleBalance(balances, "peggedUSD", totalSupply, "issued", false);
-    console.log("stellar", balances)
     return balances;
   };
 }


### PR DESCRIPTION
The negative circulating check was caused by treating Hastra wYLDS on Ethereum + Solana as YLDS bridged from Provenance.

wYLDS is a Hastra wrapper/yield product built on top of YLDS exposure, not a canonical 1:1 bridged representation of the native YLDS issued on Provenance and Stellar.

Current official YLDS issuance is roughly:

- Provenance `uylds.fcc`: ~422M YLDS
- Stellar `YLDS:GAC7...`: ~25M YLDS
- Total native/official YLDS: ~447M YLDS

Ethereum + Solana `wYLDS` supply is roughly ~600M wYLDS.

The adapter was subtracting ~600M wYLDS from Provenance only, which made Provenance circulating negative.

Because wYLDS is not capped by native Provenance/Stellar YLDS issuance, it should not be modeled as `bridgedFrom provenance` in the YLDS stablecoin supply adapter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated reported YLDS supply data to include only provenance and Stellar minted-supply entries.
  * Removed Ethereum and Solana bridged-supply entries from the displayed data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->